### PR TITLE
Fixed creation/update of po files

### DIFF
--- a/lib/qxcompiler/Analyser.js
+++ b/lib/qxcompiler/Analyser.js
@@ -878,7 +878,7 @@ module.exports = qx.Class.define("qxcompiler.Analyser", {
 
     /**
      * Updates all translations to include all msgids found in code
-     * @param the library to update
+     * @param library the library to update
      * @param locales
      * @param cb
      */
@@ -887,36 +887,42 @@ module.exports = qx.Class.define("qxcompiler.Analyser", {
 
       async.each(locales, function(locale, cb) {
         var translation = new qxcompiler.app.Translation(library, locale);
-        translation.read(function(err) {
+        translation.read().then(function(err) {
           if (err)
             return cb && cb(err);
 
-          t.__classes.forEach(function(classname) {
-            if (!classname.startsWith(library.getNamespace()))
-              return;
-            t.getClassInfo(classname, function(err, dbClassInfo) {
-              if (dbClassInfo.messageIds) {
-                dbClassInfo.messageIds.forEach(function(src) {
-                  var entry = translation.getOrCreateEntry(src.msgid);
-                  if (src.msgid_plural)
-                    entry.msgid_plural = src.msgid_plural;
-                  if (src.comment)
-                    entry.comment = src.comment;
-                  if (qx.lang.Type.isArray(src.lineNo)) {
-                    var reference = "";
-                    src.lineNo.forEach(function(lineNo) {
-                      if (reference)
-                        reference += ", ";
-                      reference += classname + ":" + lineNo;
-                    });
-                    entry.comments.reference = reference;
-                  } else
-                    entry.comments.reference = classname + ":" + lineNo;
-                });
-              }
+          Promise.all(t.__classes.map(function(classname) {
+            return new Promise((resolve) => {
+              if (!classname.startsWith(library.getNamespace()))
+                resolve();
+              t.getClassInfo(classname, function(err, dbClassInfo) {
+                if (dbClassInfo.translations) {
+                  dbClassInfo.translations.forEach(function(src) {
+                    var entry = translation.getOrCreateEntry(src.msgid);
+                    if (src.msgid_plural)
+                      entry.msgid_plural = src.msgid_plural;
+                    if (src.comment)
+                      entry.comment = src.comment;
+                    if (!entry.comments)
+                      entry.comments = {};
+                    if (qx.lang.Type.isArray(src.lineNo)) {
+                      var reference = "";
+                      src.lineNo.forEach(function(lineNo) {
+                        if (reference)
+                          reference += ", ";
+                        reference += classname + ":" + lineNo;
+                      });
+                      entry.comments.reference = reference;
+                    } else
+                      entry.comments.reference = classname + ":" + src.lineNo;
+                  });
+                }
+                resolve();
+              });
             });
+          })).then(() => {
+            translation.write(cb);
           });
-          translation.write(cb);
         });
       }, cb);
     },

--- a/lib/qxcompiler/Analyser.js
+++ b/lib/qxcompiler/Analyser.js
@@ -886,7 +886,7 @@ module.exports = qx.Class.define("qxcompiler.Analyser", {
       var t = this;
 
       async.each(locales, function(locale, cb) {
-        var translation = new qxcompiler.app.Translation(library, locale);
+        var translation = new qxcompiler.Translation(library, locale);
         translation.read().then(function(err) {
           if (err)
             return cb && cb(err);

--- a/lib/qxcompiler/targets/Target.js
+++ b/lib/qxcompiler/targets/Target.js
@@ -398,6 +398,9 @@ module.exports = qx.Class.define("qxcompiler.targets.Target", {
     },
 
     _writeTranslations: function(compileInfo, cb) {
+      const analyser = compileInfo.application.getAnalyser();
+      analyser.updateTranslations(compileInfo.library, this.getLocales());
+ 
       if (this.getWriteAllTranslations())
         this._writeAllTranslations(compileInfo, cb);
       else


### PR DESCRIPTION
I tried to fix that the compiler does not update the po files. This fix works, but I'm absolutely sure that this is pretty bad code... It probably does things at the wrong place, misuses idioms, lacks error handling and perhaps just fixes the symptoms - not the cause.

But hopefully it gives you an idea for what is really wrong or you can sanitize the code.

These are the key aspects that (I think) I have discovered:

1. `qxcompiler.Analyser.updateTranslations` seems to never be called, so a call is added to `qxcompiler.targets.Target`.
2. `qxcompiler.Translation#read` returns a promise, but it was expected to take and invoke a callback function.
3. In `updateTranslations` it is iterated over `dbClassInfo.messageIds`, but `dbClassInfo.translations` seems to be correct.
4. Also in `updateTranslations` `entry.comments` is empty. It now gets initialized with an empty object.
5. Again in `updateTranslations`, the class info is retrieved via `t.getClassInfo`, but that does not give a return value, but rather gives the result via a callback. Hence `translation.write` will not write the new entries, as they are not created yet. I'm using `Promise.all` to wait for the entries to be created; there might be a better way to do it.

I hope that his makes at least a litte bit of sense. I'm not really familiar with the code and got a little overwhelmed by it... ;)