### PR TITLE
patch for qx.$$domReady unresolved

### DIFF
--- a/lib/qxcompiler/ClassFile.js
+++ b/lib/qxcompiler/ClassFile.js
@@ -371,6 +371,8 @@ qx.Class.define("qxcompiler.ClassFile", {
       // Unresolved symbols
       dbClassInfo.unresolved = [];
       for (var name in this.__scope.unresolved) {
+        if (GLOBAL_SYMS.indexOf(name) > -1)
+          continue;
         var item = this.__scope.unresolved[name];
         // item is undefined if it has already been removed from the list
         if (item === undefined)


### PR DESCRIPTION
During compile of a simple test project you get:

qx.event.handler.Application: [220,10] Unresolved use of symbol qx.$$domReady
qx.$$domReady is a global symbol which is not resolved elsewhere in the compile code.
Therefore my suggestion is to ignore global symbols in listing as unresolved