### PR TITLE
fix bug in cldr calculation

### DIFF
--- a/lib/qxcompiler/targets/Target.js
+++ b/lib/qxcompiler/targets/Target.js
@@ -447,12 +447,20 @@ module.exports = qx.Class.define("qxcompiler.targets.Target", {
               }
               var parentLocaleId = qxcompiler.app.Cldr.getParentLocale(localeId);
               if (parentLocaleId)
-                return loadLocaleData(parentLocaleId);
+                return accumulateCldr(parentLocaleId);
               return combinedCldr;
             });
         }
         
-        return accumulateCldr(localeId);
+        return accumulateCldr(localeId)
+          .then(() => {
+            var pos = localeId.indexOf('_');
+            if (pos > -1) {
+              var parentLocaleId = localeId.substring(0, pos);
+              return accumulateCldr(parentLocaleId);
+            }
+            return combinedCldr;
+          });
       }
       
       var promises = t.getLocales().map((localeId) => {


### PR DESCRIPTION
Fixes a bug in CLDR; locales inherit from explicit parentLocale *and* implicit from their prefix (eg `en_gb` inherits from `en_001` and `en`)