### PR TITLE
Fixed reading po file with multiline plural msgstr

### DIFF
--- a/lib/qxcompiler/app/Translation.js
+++ b/lib/qxcompiler/app/Translation.js
@@ -209,7 +209,7 @@ module.exports = qx.Class.define("qxcompiler.app.Translation", {
   
                 if (line[0] == '"' && line[line.length - 1] == '"') {
                   line = line.substring(1, line.length - 1);
-                  if (lastKey === null || entry[lastKey] === undefined)
+                  if (!lastKey.match(/^.*\[\d+\]$/) && (lastKey === null || entry[lastKey] === undefined))
                     log.error("Cannot interpret line because there is no key to append to, line " + (lineNo+1));
                   else
                     set(lastKey, line, true);


### PR DESCRIPTION
If a po file contains multiline entries for plural strings like

```po
msgid ""
"foo"
msgid_plural ""
"bar"
msgstr[0] ""
"baz"
msgstr[1] ""
"druggeljug"
```

the compiler complains with errors like

```
2017-12-20 08:28:51.160 [error] translation     Cannot interpret line because there is no key to append to, line 6, lastKey: '', line: 'baz'
2017-12-20 08:28:51.161 [error] translation     Cannot interpret line because there is no key to append to, line 8, lastKey: '', line: 'druggeljug'
```

and drops the `msgstr[...]` entries:

```po
msgid "foo"
msgid_plural "bar"
msgstr[0] ""
msgstr[1] ""
```

The command `set(lastKey, line, true)` can handle entries like this, but is not called because of the condition in line 212.

The fix checks adds an additional check if the entry ends with `[<number>]`.