### PR TITLE
Fixed writing of translation entries

### DIFF
--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -654,7 +654,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
               .then((translation) => {
                   var id = library.getNamespace() + ":" + localeId; 
                   translations[id] = translation;
-                  writeEntry(translation.getEntry(""));
+                  writeEntry(localeId, translation.getEntry(""));
                 })
             );
         });
@@ -671,7 +671,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
                 var id = dbClassInfo.libraryName + ":" + localeId;
                 var translation = translations[id];
                 dbClassInfo.translations.forEach(function(transInfo) {
-                  writeEntry(translation.getEntry(transInfo.msgid));
+                  writeEntry(localeId, translation.getEntry(transInfo.msgid));
                 });
               });
             });


### PR DESCRIPTION
As you can see in [Target.js L634](https://github.com/mbgonicus/qooxdoo-compiler/blob/8831b76505d56ec1c850ad0015eefbf22a434dfe/lib/qx/tool/compiler/targets/Target.js#L634), the function `writeEntry` has the `localeId` as its first parameter:

```javascript
function writeEntry(localeId, entry) {
```

The call of `writeEntry` in the corrected lines did not state the `localeId` but just the entry. Therefore, the translations are never written to `compileInfo` and never arrive in the compiled application.