### PR TITLE
Improve qx contrib list readability

### DIFF
--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -5,14 +5,14 @@
    http://qooxdoo.org
 
    Copyright:
-     2017 Christian Boulanger
+   2017 Christian Boulanger
 
    License:
-     MIT: https://opensource.org/licenses/MIT
-     See the LICENSE file in the project's top-level directory for details.
+   MIT: https://opensource.org/licenses/MIT
+   See the LICENSE file in the project's top-level directory for details.
 
    Authors:
-     * Christian Boulanger (info@bibliograph.org, @cboulanger)
+   * Christian Boulanger (info@bibliograph.org, @cboulanger)
 
 ************************************************************************ */
 
@@ -22,35 +22,36 @@ require("../Contrib");
 
 require("qooxdoo");
 const semver = require("semver");
+const columnify = require("columnify");
 
 /**
  * Lists compatible contrib libraries
  */
 qx.Class.define("qx.tool.cli.commands.contrib.List", {
   extend: qx.tool.cli.commands.Contrib,
-
   statics: {
     getYargsCommand: function() {
       return {
-        command: 'list [repository]',
-        describe: 'if no repository name is given, lists all available contribs that are compatible with the project\'s qooxdoo version ("--all" lists incompatible ones as well). Otherwise, list all compatible contrib libraries.',
+        command: "list [repository]",
+        describe:
+          'if no repository name is given, lists all available contribs that are compatible with the project\'s qooxdoo version ("--all" lists incompatible ones as well). Otherwise, list all compatible contrib libraries.',
         builder: {
-          'all': {
-            alias: 'a',
-            describe: 'Show all versions, including incompatible ones'
+          all: {
+            alias: "a",
+            describe: "Show all versions, including incompatible ones"
           },
-          "verbose": {
-            alias: 'v',
-            describe: 'Verbose logging'
+          verbose: {
+            alias: "v",
+            describe: "Verbose logging"
           }
         },
         handler: function(argv) {
           return new qx.tool.cli.commands.contrib.List(argv)
-            .process()
-            .catch((e) => {
-              console.error(e.stack || e.message);
-              process.exit(1);
-            });
+          .process()
+          .catch(e => {
+            console.error(e.stack || e.message);
+            process.exit(1);
+          });
         }
       };
     }
@@ -61,84 +62,184 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
     /**
      * Lists contrib libraries compatible with the current project
      */
-    process: async function() {
-  
-      let argv = this.argv;
+    process: async function() 
+    {
       let repos_cache = this.getCache().repos;
-      let list = repos_cache.list;
-      
-      if ( repos_cache.list.length == 0 ){
-        throw new qx.tool.cli.Utils.UserError("You need to execute 'qx contrib update' first.");
-      }
-      
-      let qooxdoo_version = await this.getUserQxVersion();
-      if(argv.verbose) console.log(`>>> qooxdoo version:  ${qooxdoo_version}`);
-     
-      // has a repository name been given?
-      let list_repo_only = argv.repository;
-      
-      if( list_repo_only && ! this.getCache().repos.data[list_repo_only] ){
-        throw new qx.tool.cli.Utils.UserError(`'${list_repo_only}' does not exist or is not a contrib library.`);
-      }      
 
-      // list the latest release of each library compatible with the current qooxdoo version
+      if ( repos_cache.list.length == 0 ) {
+        throw new qx.tool.cli.Utils.UserError(
+          "You need to execute 'qx contrib update' first."
+        );
+      }
+
+      let qooxdoo_version = await this.getUserQxVersion();
+      let num_compat_repos = this.__createIndexes(qooxdoo_version);
+      if (this.argv.verbose) {
+        console.log(`>>> We have ${num_compat_repos} contrib repositories which contain libraries compatible with qooxdoo version ${qooxdoo_version}`);
+      }
+
+      if ( num_compat_repos === 0 && ! this.argv.all ) {
+        console.info(
+          `Currently, no contrib libraries with releases compatible with qooxdoo version ${qooxdoo_version} exist. Try 'qx contrib list --all'.`
+        );
+        return; 
+      }
+
+      // detailed repo information
+      let repo = this.argv.repository;
+      if ( repo ){
+        if ( ! repos_cache.list.includes(repo) ){
+          throw new qx.tool.cli.Utils.UserError(
+            `Repository ${repo} does not exist or is not a qooxdoo contrib repo.`
+          );
+        }
+        if( this.__libraries[repo] && this.__libraries[repo].length ){
+          let columnify_options = {
+            columnSplitter: '   ',
+            config: {
+              description: { maxWidth: 60 },
+              compatibility : {
+                dataTransform: function(data) {
+                  switch( data ){
+                    case "false" : return "not compatible / untested";
+                    case "true"  : return "√";
+                  }
+                }
+              }
+            }
+          }           
+          console.info(columnify( this.__libraries[repo], columnify_options ) );
+        } else if( this.argv.verbose ) {
+          console.info(`Repository ${repo} does not contain suitable contrib libraries.`);
+        }
+        return;
+      } 
+
+      // list output 
+      let columnify_options = {
+        columnSplitter: '   ',
+        config: {
+          description: { maxWidth: 60 },
+          latestCompatible : {
+            dataTransform: function(data) {
+              return data == "false" ? "not compatible / untested" : data;
+            }
+          }
+        }
+      } 
+      let list = 
+        this.argv.all ?
+        this.__repositories :
+        this.__repositories.filter( item => item.latestCompatible );
+
+      console.info( columnify( list, columnify_options ));
+
+      // save to cache
+      this.getCache().compat[qooxdoo_version] = this.__latestCompatible[qooxdoo_version];
+      this.saveCache();      
+    },
+
+    /**
+     * compatibility indexes
+     */
+    __repositories : [],
+    __libraries : {},
+    __latestCompatible : {},
+
+    /**
+     * Create compatibilty indexes of repositories and the contained libraries
+     * @param qooxdoo_version {String} The qooxdoo version to check compatibiity with
+     * @return {Number} The number of contrib repositories containing compatible libraries
+     */
+    __createIndexes : function(qooxdoo_version)
+    {
+      let repos_cache = this.getCache().repos;
       let num_compat_repos = 0;
-      for ( let repo_name of list) {
-        
-        // if a repository name has been passed, list all releases of this repo, otherwise skip
-        if ( list_repo_only && repo_name !== list_repo_only ) continue;
-        
+      let result_repo_list = [];
+      if (this.__latestCompatible[qooxdoo_version] === undefined) {
+        this.__latestCompatible[qooxdoo_version] = {};
+      } 
+
+      // iterate over repositories
+      for (let repo_name of repos_cache.list) {
         // get releases version
         let repo_data = repos_cache.data[repo_name];
         let tag_names = repo_data.releases.list;
         let { description } = repo_data;
         let releaseInfo = [];
-      
-        // iterate over releases, at least one of the libraries in the release needs to be compatible
+        // iterate over releases, at least one of the libraries in the release
+        // needs to be compatible
         let hasCompatibleRelease = false;
-        for (let tag_name of tag_names){
+        for (let tag_name of tag_names) {
           let release_data = repo_data.releases.data[tag_name];
           let { prerelease, manifests } = release_data;
-          let compatible_releases = [];
-          // iterate over manifests in that release 
-          for ( let { qx_versions, info } of manifests ){
-            if( info === undefined ){ 
-              if ( argv.verbose) console.warn( `!!! Undefined info field for ${repo_name}/${tag_name}`);
+          let compatible_libraries = [];
+          // iterate over manifests in that release
+          for ( let { qx_versions, info } of manifests) {
+            
+            if (info === undefined) {
+              if (this.argv.verbose) {
+                console.warn(`!!! ${repo_name}/${tag_name}: Undefined info field. `);
+              }
               continue;
             }
-            let isCompatible = semver.satisfies(qooxdoo_version, qx_versions, true);
-            compatible_releases.push(`  - ${info.name} ${isCompatible?'':'(incompatible, requires qooxdoo ' + qx_versions +')'}`);
-            // use the latest compatible release
-            if( this.getCache().compat[qooxdoo_version] === undefined ){
-              this.getCache().compat[qooxdoo_version] = {};
+            
+            // library version should match tag name
+            let version = info.version;
+            let tag_version = tag_name.replace(/v/,'');
+            if( version != tag_version ){
+              if (this.argv.verbose) {
+                console.warn(`!!! ${repo_name}/${tag_name}/${info.name}: mismatch between tag version ${tag_version} and library version ${version}.`);
+              }
+              continue;            
             }
-            if ( ! hasCompatibleRelease && isCompatible && ! prerelease){
-              this.getCache().compat[qooxdoo_version][repo_name]=tag_name;
+
+            // check compatibility of library
+            let compatibility = semver.satisfies(
+              qooxdoo_version,
+              qx_versions,
+              true
+            );
+
+            // prepare indexes
+            if (this.__libraries[repo_name] === undefined) {
+              this.__libraries[repo_name] = [];
+            }   
+          
+            // use the latest compatible release, i.e the one that satisfies the following conditions:
+            // 1) must be semver-compatible with the qooxdoo version
+            // 2) must be the higher than any other version found so far
+            // 3) should not be a pre-release unless there are no other compatible releases
+            let latestCompatibleRelease = this.__latestCompatible[qooxdoo_version][repo_name];
+            let latestCompatibleVersion = latestCompatibleRelease ? latestCompatibleRelease.replace(/v/,'') : undefined;
+            if ( compatibility === true && 
+              ( latestCompatibleRelease === undefined || 
+                ( semver.gt( tag_version, latestCompatibleVersion, false ) && ! prerelease ) 
+              )
+            ) {
+              this.__latestCompatible[qooxdoo_version][repo_name] = tag_name;
               hasCompatibleRelease = true;
             }
-          }
-          if ( compatible_releases.length)
-          {
-            releaseInfo.push(`  ${tag_name}${prerelease?" (prerelease)":""}:`);
-            releaseInfo = releaseInfo.concat(compatible_releases);
+
+            // save data 
+            this.__libraries[repo_name].push({
+              name: info.name,
+              version,
+              compatibility,
+              requires: qx_versions
+            });          
           }
         }
-        if( ! hasCompatibleRelease && ! argv.all ) continue;
-        if( hasCompatibleRelease ) num_compat_repos++;
-        let title = `${repo_name} ${hasCompatibleRelease?"":"(incompatible)"}`;
-        let padding = " ".repeat(Math.max(50-title.length,1));
-        console.info(title +  padding + description);
-        if( releaseInfo.length && (argv.all || list_repo_only ) ) {
-          console.info(releaseInfo.join("\n"));
-        }
+        if (hasCompatibleRelease) num_compat_repos++;
+
+        // add to list
+        this.__repositories.push({
+          name: repo_name,
+          description,
+          latestCompatible : hasCompatibleRelease ? this.__latestCompatible[qooxdoo_version][repo_name] : false 
+        });
       }
-      if ( num_compat_repos === 0 && ! argv.all ){
-        let msg=''+
-          `Currently, no contrib libraries with stable releases compatible with `+
-          `qooxdoo version ${qooxdoo_version} exist. Try 'qx contrib list --all'.`;
-        console.info(msg);
-      }
-      this.saveCache();
+      return num_compat_repos;
     }
   }
 });

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -179,7 +179,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
             
             if (info === undefined) {
               if (this.argv.verbose) {
-                console.warn(`!!! ${repo_name}/${tag_name}: Undefined info field. `);
+                console.warn(`>>> Ignoring ${repo_name}/${tag_name}: Undefined info field. `);
               }
               continue;
             }
@@ -189,7 +189,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
             let tag_version = tag_name.replace(/v/,'');
             if( version != tag_version ){
               if (this.argv.verbose) {
-                console.warn(`!!! ${repo_name}/${tag_name}/${info.name}: mismatch between tag version ${tag_version} and library version ${version}.`);
+                console.warn(`>>> Ignoring ${repo_name} ${tag_name}: mismatch between tag version '${tag_version}' and library version '${version}'.`);
               }
               continue;            
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "absolute": {
       "version": "0.0.1",
@@ -134,7 +133,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "dev": true,
       "requires": {
         "delegates": "1.0.0",
         "readable-stream": "2.3.3"
@@ -170,8 +168,7 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -210,14 +207,12 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "dev": true
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
     },
     "ast-transform": {
       "version": "0.0.0",
@@ -287,26 +282,22 @@
     "async-foreach": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-      "dev": true
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
     },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
-      "dev": true
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "axios": {
       "version": "0.15.3",
@@ -1235,7 +1226,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -1258,7 +1248,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3"
       }
@@ -1299,7 +1288,6 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -1435,7 +1423,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
       "requires": {
         "camelcase": "2.1.1",
         "map-obj": "1.0.1"
@@ -1444,8 +1431,7 @@
         "camelcase": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         }
       }
     },
@@ -1457,8 +1443,7 @@
     "caseless": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-      "dev": true
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
     },
     "caw": {
       "version": "2.0.1",
@@ -1611,11 +1596,19 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "columnify": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+      "requires": {
+        "strip-ansi": "3.0.1",
+        "wcwidth": "1.0.1"
+      }
+    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -1699,7 +1692,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-      "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
         "which": "1.3.0"
@@ -1709,7 +1701,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
       "requires": {
         "boom": "2.10.1"
       }
@@ -1718,7 +1709,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
       "requires": {
         "array-find-index": "1.0.2"
       }
@@ -1735,7 +1725,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -1743,8 +1732,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -1864,7 +1852,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true,
       "requires": {
         "clone": "1.0.2"
       }
@@ -1902,14 +1889,12 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "depd": {
       "version": "1.1.2",
@@ -2016,7 +2001,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -2773,8 +2757,7 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extend-shallow": {
       "version": "2.0.1",
@@ -2806,8 +2789,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "falafel": {
       "version": "2.1.0",
@@ -2932,7 +2914,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true,
       "requires": {
         "path-exists": "2.1.0",
         "pinkie-promise": "2.0.1"
@@ -3005,14 +2986,12 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
@@ -3040,30 +3019,6 @@
         "klaw": "1.3.1",
         "path-is-absolute": "1.0.1",
         "rimraf": "2.6.2"
-      }
-    },
-    "fs-tools": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/fs-tools/-/fs-tools-0.2.11.tgz",
-      "integrity": "sha1-ZKYzkRn42mh75NH9vaN+4PiOZEw=",
-      "dev": true,
-      "requires": {
-        "async": "0.2.10",
-        "lodash": "2.4.2"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
       }
     },
     "fs.realpath": {
@@ -3864,7 +3819,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "inherits": "2.0.3",
@@ -3901,7 +3855,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
       "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-      "dev": true,
       "requires": {
         "globule": "1.2.0"
       }
@@ -3935,8 +3888,7 @@
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-      "dev": true
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-stream": {
       "version": "3.0.0",
@@ -3947,7 +3899,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -3955,8 +3906,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -4023,7 +3973,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
       "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2",
         "lodash": "4.17.4",
@@ -4074,74 +4023,10 @@
         "toml": "2.3.3"
       }
     },
-    "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
-    },
     "har-validator": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "commander": "2.11.0",
@@ -4203,7 +4088,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
       "requires": {
         "boom": "2.10.1",
         "cryptiles": "2.0.5",
@@ -4214,8 +4098,7 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -4258,7 +4141,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
       "requires": {
         "assert-plus": "0.2.0",
         "jsprim": "1.4.1",
@@ -4293,14 +4175,12 @@
     "in-publish": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
-      "dev": true
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
     },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
@@ -4637,14 +4517,12 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-      "dev": true
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
     "isarray": {
       "version": "1.0.0",
@@ -4667,8 +4545,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "isurl": {
       "version": "1.0.0",
@@ -4702,7 +4579,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
       "optional": true
     },
     "jsesc": {
@@ -4713,8 +4589,7 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -4737,8 +4612,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json-to-ast": {
       "version": "git+https://github.com/johnspackman/json-to-ast.git#a42fbe89a4f2033062213c49bfec7cf429d94db6"
@@ -4780,7 +4654,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -4791,8 +4664,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -4813,15 +4685,6 @@
       "dev": true,
       "requires": {
         "dot": "1.1.2"
-      }
-    },
-    "jstransformer-handlebars": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer-handlebars/-/jstransformer-handlebars-1.0.0.tgz",
-      "integrity": "sha1-B20FtOyLQ7h0cprFflnw6t+wEao=",
-      "dev": true,
-      "requires": {
-        "handlebars": "4.0.11"
       }
     },
     "kind-of": {
@@ -4867,7 +4730,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "parse-json": "2.2.0",
@@ -4905,8 +4767,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.endswith": {
       "version": "4.2.1",
@@ -4926,8 +4787,7 @@
     "lodash.mergewith": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
-      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
-      "dev": true
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
     },
     "lodash.pickby": {
       "version": "4.6.0",
@@ -4956,7 +4816,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
       "requires": {
         "currently-unhandled": "0.4.1",
         "signal-exit": "3.0.2"
@@ -4994,8 +4853,7 @@
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-      "dev": true
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "marked": {
       "version": "0.3.12",
@@ -5020,7 +4878,6 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true,
       "requires": {
         "camelcase-keys": "2.1.0",
         "decamelize": "1.2.0",
@@ -5037,8 +4894,7 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
@@ -5069,17 +4925,6 @@
         "unyield": "0.0.1",
         "ware": "1.3.0",
         "win-fork": "1.1.1"
-      }
-    },
-    "metalsmith-discover-partials": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/metalsmith-discover-partials/-/metalsmith-discover-partials-0.1.0.tgz",
-      "integrity": "sha1-+PI5O8vV4XKspzFc3BFgHhOU+yM=",
-      "dev": true,
-      "requires": {
-        "defaults": "1.0.3",
-        "fs-tools": "0.2.11",
-        "handlebars": "4.0.11"
       }
     },
     "metalsmith-filenames": {
@@ -5268,7 +5113,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-      "dev": true,
       "requires": {
         "fstream": "1.0.11",
         "glob": "7.1.2",
@@ -5288,8 +5132,7 @@
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         }
       }
     },
@@ -5297,7 +5140,6 @@
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
       "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
-      "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
         "chalk": "1.1.3",
@@ -5355,7 +5197,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
       "requires": {
         "abbrev": "1.1.1"
       }
@@ -5407,7 +5248,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
         "console-control-strings": "1.1.0",
@@ -5423,8 +5263,7 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -5475,16 +5314,6 @@
         "mimic-fn": "1.1.0"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.2"
-      }
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -5514,7 +5343,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
       "requires": {
         "lcid": "1.0.0"
       }
@@ -5528,7 +5356,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -5614,7 +5441,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
       "requires": {
         "pinkie-promise": "2.0.1"
       }
@@ -5648,7 +5474,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
@@ -5744,8 +5569,7 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qooxdoo": {
       "version": "5.0.1",
@@ -5760,8 +5584,7 @@
     "qs": {
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-      "dev": true
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
     },
     "quote-stream": {
       "version": "1.0.2",
@@ -5837,7 +5660,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
       "requires": {
         "load-json-file": "1.1.0",
         "normalize-package-data": "2.4.0",
@@ -5848,7 +5670,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
       "requires": {
         "find-up": "1.1.2",
         "read-pkg": "1.1.0"
@@ -5928,7 +5749,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
       "requires": {
         "indent-string": "2.1.0",
         "strip-indent": "1.0.1"
@@ -6019,7 +5839,6 @@
       "version": "2.79.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-      "dev": true,
       "requires": {
         "aws-sign2": "0.6.0",
         "aws4": "1.6.0",
@@ -6153,7 +5972,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2",
         "lodash": "4.17.4",
@@ -6164,14 +5982,12 @@
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
           "requires": {
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1",
@@ -6182,7 +5998,6 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "dev": true,
           "requires": {
             "camelcase": "3.0.0",
             "cliui": "3.2.0",
@@ -6210,7 +6025,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-      "dev": true,
       "requires": {
         "js-base64": "2.3.2",
         "source-map": "0.4.4"
@@ -6220,7 +6034,6 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
           "requires": {
             "amdefine": "1.0.1"
           }
@@ -6369,7 +6182,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -6430,7 +6242,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
-      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -6445,8 +6256,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -6572,7 +6382,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
-      "dev": true,
       "requires": {
         "readable-stream": "2.3.3"
       }
@@ -6609,8 +6418,7 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -6624,7 +6432,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
       "requires": {
         "is-utf8": "0.2.1"
       }
@@ -6646,7 +6453,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
       "requires": {
         "get-stdin": "4.0.1"
       }
@@ -6784,7 +6590,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "dev": true,
       "requires": {
         "block-stream": "0.0.9",
         "fstream": "1.0.11",
@@ -6869,7 +6674,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
-      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       }
@@ -6877,8 +6681,7 @@
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-      "dev": true
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "trim-repeated": {
       "version": "1.0.0",
@@ -6897,7 +6700,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
-      "dev": true,
       "requires": {
         "glob": "6.0.4"
       },
@@ -6906,7 +6708,6 @@
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
           "requires": {
             "inflight": "1.0.6",
             "inherits": "2.0.3",
@@ -6920,14 +6721,12 @@
     "tunnel-agent": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "dev": true
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -7078,8 +6877,7 @@
     "uuid": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.0.tgz",
-      "integrity": "sha512-qC0vMFX6q6ee8JaoTF2Om1uL8KAV1ATUjVaHRxLiPJkIsp8JZl6ZjG0MIB+twZFLbi1vXj30rqj4zlqYiOS9xg==",
-      "dev": true
+      "integrity": "sha512-qC0vMFX6q6ee8JaoTF2Om1uL8KAV1ATUjVaHRxLiPJkIsp8JZl6ZjG0MIB+twZFLbi1vXj30rqj4zlqYiOS9xg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
@@ -7099,7 +6897,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -7109,8 +6906,7 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
     },
@@ -7121,6 +6917,14 @@
       "dev": true,
       "requires": {
         "wrap-fn": "0.1.5"
+      }
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "requires": {
+        "defaults": "1.0.3"
       }
     },
     "which": {
@@ -7134,8 +6938,7 @@
     "which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
     },
     "wide-align": {
       "version": "1.1.2",
@@ -7385,7 +7188,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-      "dev": true,
       "requires": {
         "camelcase": "3.0.0"
       },
@@ -7393,8 +7195,7 @@
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-          "dev": true
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "test": "cross-os test.os"
-  },  
+  },
   "cross-os": {
     "test.os": {
       "win32": "test\\test.win32.cmd",
@@ -41,6 +41,7 @@
     "babel-types": "^6.26.0",
     "babylon": "^6.18.0",
     "chokidar": "^1.7.0",
+    "columnify": "^1.5.4",
     "download": "^6.0.0",
     "es6-promisify-all": "^0.1.0",
     "eslint": "^4.13.0",
@@ -57,8 +58,8 @@
     "jsonlint": "^1.6.2",
     "node-fetch": "^1.7.3",
     "node-sass": "^4.7.2",
-    "qooxdoo-sdk": "^6.0.0-alpha",
     "qooxdoo": "^5.0.1",
+    "qooxdoo-sdk": "^6.0.0-alpha",
     "rimraf": "^2.6.2",
     "semver": "^5.3.0",
     "tmp": "0.0.33",


### PR DESCRIPTION
This substantially improves the readability of the output of `qx contrib list` by using the NPM columnify package. 

```
$ qx contrib list
NAME                         DESCRIPTION                                                  LATESTCOMPATIBLE
cboulanger/qx-contrib-test   This is a test contribution for the qooxdoo contrib system   v1.0.28

$ qx contrib list --all
NAME                               DESCRIPTION                                                    LATESTCOMPATIBLE
cajus/capture                      Qooxdoo contribution to capture still images from life video   not compatible / untested
cboulanger/qooxdoo-contrib-test    A test contrib library                                         not compatible / untested
cboulanger/qx-contrib-Dialog       A set of often used dialog widgets for the qooxdoo framework   not compatible / untested
cboulanger/qx-contrib-TokenField   A widget implementing the token field concept known from Mac   not compatible / untested
                                   OS X for the qooxdoo framework
cboulanger/qx-contrib-test         This is a test contribution for the qooxdoo contrib system     v1.0.28
ergobyte/qookery                   Declarative UI Building for Qooxdoo                            not compatible / untested
gonicus/qooxdoo-svg                Fork of http://qooxdoo.org/contrib/project/svg with minimal    not compatible / untested
                                   fixes
johnspackman/UploadMgr             Uploads files with background uploads and progress feedback    not compatible / untested
                                   on modern browsers
oetiker/CanvasCell                 Embeddable Charts for Qooxdoo table widgets                    not compatible / untested
oetiker/ComboTable                 Qx Selectbox with incermental search                           not compatible / untested
oetiker/Cropper                    Qx Widget to visually select part of another widget            not compatible / untested
oetiker/QxD3                       use D3.js within qooxdoo                                       not compatible / untested
oetiker/QxDyGraphs                 QxDyGraphs Charting Library for time series data               not compatible / untested
oetiker/QxJqPlot                   Use jqPlot from within qooxdoo.                                not compatible / untested
oetiker/QxTangible                 A Qooxdoo Theme inspired by Googles Material Design            not compatible / untested
oetiker/UploadWidget               An UploadWidget for Qooxdoo                                    not compatible / untested

qx contrib list cboulanger/qx-contrib-Dialog
NAME     VERSION   COMPATIBILITY               REQUIRES
Dialog   1.1       not compatible / untested   2.0 || 2.1 || 3.0 || 3.5 || 4.0
Dialog   1.0       not compatible / untested   2.0 || 2.1 || 3.0 || 3.5 || 3.6

$ qx contrib list cboulanger/qx-contrib-test
NAME   VERSION   COMPATIBILITY   REQUIRES
test   1.0.28    √               6.0.0-alpha - 6.x
test   1.0.27    √               6.0.0-alpha - 6.x
test   1.0.26    √               6.0.0-alpha - 6.x
test   1.0.25    √               6.0.0-alpha - 6.x
test   1.0.14    √               6.0.0-alpha - 6.x
test   1.0.13    √               6.0.0-alpha - 6.x
test   1.0.12    √               6.0.0-alpha - 6.x
```
Contrib authors will soon be asked to make new releases so that the list of compatible contribs gets a bit longer :-) 
