### PR TITLE
Fix index.html

### DIFF
--- a/lib/qx/tool/compiler/app/Translation.js
+++ b/lib/qx/tool/compiler/app/Translation.js
@@ -242,6 +242,7 @@ module.exports = qx.Class.define("qx.tool.compiler.app.Translation", {
                 var value = m[2];
                 if (value.length >= 2 && value[0] == '"' && value[value.length - 1] == '"') {
                   value = value.substring(1, value.length - 1);
+                  value = value.replace(/\\t/g, "\t").replace(/\\r/g, "\r").replace(/\\n/g, "\n").replace(/\\"/g, '"');
                   set(key, value);
                 }
               });
@@ -269,7 +270,7 @@ module.exports = qx.Class.define("qx.tool.compiler.app.Translation", {
       function write(key, value) {
         if (value === undefined || value === null)
           return;
-        value = value.replace(/\\n(.)/g, function(a, c) { return "\\n\"\n\"" + c; });
+        value = value.replace(/\t/g, "\\t").replace(/\r/g, "\\r").replace(/\n/g, "\\n").replace(/"/g, '\\"');
         lines.push(key + " \"" + value + "\"");
       }
       var t = this;

--- a/lib/qx/tool/compiler/app/loader-server.tmpl.js
+++ b/lib/qx/tool/compiler/app/loader-server.tmpl.js
@@ -151,7 +151,10 @@
 
       loadScriptList: function(list) {
         list.forEach(function(uri) {
-          load(uri);
+          let f = load(uri);
+		  if (typeof f === "function") {
+			  window[f.name] = f;
+		  }
         });
       },
 

--- a/lib/qx/tool/compiler/app/loader-server.tmpl.js
+++ b/lib/qx/tool/compiler/app/loader-server.tmpl.js
@@ -151,10 +151,7 @@
 
       loadScriptList: function(list) {
         list.forEach(function(uri) {
-          let f = load(uri);
-		  if (typeof f === "function") {
-			  window[f.name] = f;
-		  }
+          load(uri);
         });
       },
 


### PR DESCRIPTION
#121: In case of type node or rhino index.html is not generated and boot.js is named to application.js
#57, #64: Added a new parameter to compile.json, application: writeIndexHtmlToRoot. If set to true an <base href="appdir" /> is written to index.html. So the application can be used in the root of the webserver.