### PR TITLE
fix for #57, #64: write base tag to index.html

### DIFF
--- a/docs/cli/compile-json.md
+++ b/docs/cli/compile-json.md
@@ -67,6 +67,7 @@ The `applications` key is an array of objects, and each object can contain:
 application.
 `loaderTemplate` - (**optional**, **advanced**) this is the boot loader template file, usually determined automatically from the application `type` 
 `minify` - (**optional**) determines the minification to be used for this application, if the target supports it; overrides other settings.  Can be `off`, `minify`, `mangle` or `beautify`; takes precedence over the target's `minify` setting.
+- `writeIndexHtmlToRoot` - (**optional** ) if true the index.html file will be written to the target output directory. Allowed only once if you have more then one application. The index.html get's an <base href="appname" /> if set to true.
 
 A complete example is:
 ```

--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -326,6 +326,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       if (t.argv["app-name"])
         appNames = t.argv["app-name"].split(',');
       
+      let hasFoundIndexHtmlToRoot = false;  
       data.applications.forEach(function(appData, appIndex) {
         if (appNames && appNames.indexOf(appData.name) == -1)
           return;
@@ -337,6 +338,13 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
               app[fname](appData[name]);
             }
           });
+        if (app.isBrowserApp() && appData.writeIndexHtmlToRoot) {
+           if (hasFoundIndexHtmlToRoot) {
+              throw new qx.tool.cli.Utils.UserError("Error: writeIndexHtmlToRoot=true is only allowed for one application!");
+           }
+           hasFoundIndexHtmlToRoot = true;  
+           app.setWriteIndexHtmlToRoot(true);  
+        }
         if (appData.uri)
           app.setSourceUri(appData.uri);
         if (appData.title)

--- a/lib/qx/tool/compiler/app/Application.js
+++ b/lib/qx/tool/compiler/app/Application.js
@@ -148,7 +148,15 @@ qx.Class.define("qx.tool.compiler.app.Application", {
     loaderTemplate: {
       nullable: false,
       check: "String"
-    }
+    },
+
+    /**
+     * Writes the index.html into root instead of app dir
+     */
+    writeIndexHtmlToRoot: {
+      init: false,
+      check: "Boolean"
+    },
   },
 
   members: {

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -235,9 +235,17 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
      * Returns the root for applications
      */
     getApplicationRoot: function(application) {
-      return path.join(this.getOutputDir(), application.getOutputPath() || application.getName()) + "/";
+      return path.join(this.getOutputDir(), this.getProjectDir(application)) + "/";
     },
     
+    /**
+     * Returns the project dir
+     * 
+     * @returns String
+     */
+    getProjectDir: function (application) {
+       return application.getOutputPath() || application.getName();
+    }, 
     /**
      * Returns the URI for the root of the output, relative to the application
      */
@@ -843,27 +851,30 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
     _writeIndexHtml: async function(compileInfo) {
       var t = this;
       var application = compileInfo.application;
-      var appRootDir = this.getApplicationRoot(application);
+      
 
       if (!t.isGenerateIndexHtml())
         return Promise.resolve();
       
+      var appRootDir = application.getWriteIndexHtmlToRoot()? this.getOutputDir(): this.getApplicationRoot(application);
+
       function writeDefaultIndexHtml() {
-        return writeFile(appRootDir + t.getScriptPrefix() + "index.html",
-            "<!DOCTYPE html>\n" +
-            "<html>\n" +
-            "<head>\n" +
-            "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />\n" +
-            "  <title>" + (application.getTitle()||"Qooxdoo Application") + "</title>\n" +
-            "</head>\n" +
-            "<body>\n" +
-            "  <!-- This index.html can be customised by creating a boot/index.html (do not include Qooxdoo application script tags like\n" +
-            "       the one below because they will be added automatically)\n" +
-            "    -->\n" +
-            "  <script type=\"text/javascript\" src=\"" + t.getScriptPrefix() + "boot.js\"></script>\n" +
-            "</body>\n" +
-            "</html>\n", 
-            { encoding: "utf8" });
+        let s =
+          "<!DOCTYPE html>\n" +
+          "<html>\n" +
+          "<head>\n" +
+          (application.getWriteIndexHtmlToRoot() ? ("  <base href=\"" + t.getProjectDir(application) + "/\" />\n") : "") +  
+          "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />\n" +
+          "  <title>" + (application.getTitle()||"Qooxdoo Application") + "</title>\n" +
+          "</head>\n" +
+          "<body>\n" +
+          "  <!-- This index.html can be customised by creating a boot/index.html (do not include Qooxdoo application script tags like\n" +
+          "       the one below because they will be added automatically)\n" +
+          "    -->\n" +
+          "  <script type=\"text/javascript\" src=\"" + t.getScriptPrefix() + "boot.js\"></script>\n" +
+          "</body>\n" +
+          "</html>\n";        
+        return writeFile(appRootDir + t.getScriptPrefix() + "index.html", s, { encoding: "utf8" });
       }
       
       var classname = application.getClassName();
@@ -883,9 +894,13 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
       await qx.tool.compiler.files.Utils.sync(bootDir, appRootDir, (from, to) => from != "index.html");
       var stats = await stat(path.join(bootDir, "index.html"));
       if (stats.isFile()) {
-        var html = await readFile(path.join(bootDir, "index.html"), { encoding: "utf8" });
-        var str = "<script type=\"text/javascript\" src=\"" + t.getScriptPrefix() + "boot.js\"></script>\n</body>";
-        var after = html.replace(/\<\/body\>/, str);
+        let html = await readFile(path.join(bootDir, "index.html"), { encoding: "utf8" });
+        let str = "<script type=\"text/javascript\" src=\"" + t.getScriptPrefix() + "boot.js\"></script>\n</body>";
+        let after = html.replace(/\<\/body\>/, str);
+        if (application.getWriteIndexHtmlToRoot()) {
+          let str = "<base href=\"" + this.getProjectDir(application) + "/\" />\n</head>";
+          after = after.replace(/\<\/head\>/, str);
+        }
         return writeFile(appRootDir + t.getScriptPrefix() + "index.html", after, { encoding: "utf8" });
       } else {
         return writeDefaultIndexHtml() ;

--- a/tool/cli/templates/skeleton/desktop/compile.tmpl.json
+++ b/tool/cli/templates/skeleton/desktop/compile.tmpl.json
@@ -20,7 +20,8 @@
     {
       "class": "${namespace}.Application",
       "theme": "${namespace}.theme.Theme",
-      "name": "${namespace}"
+      "name": "${namespace}",
+      "writeIndexHtmlToRoot": true
     }
   ],
 

--- a/tool/cli/templates/skeleton/mobile/compile.tmpl.json
+++ b/tool/cli/templates/skeleton/mobile/compile.tmpl.json
@@ -19,7 +19,8 @@
   "applications": [
     {
       "class": "${namespace}.Application",
-      "name": "${namespace}"
+      "name": "${namespace}",
+      "writeIndexHtmlToRoot": true
     }
   ],
 


### PR DESCRIPTION
Add a new parameter to compile.json, application: writeIndexHtmlToRoot. 
If set to true <base href="appdir">/ is written to index.html. 
So the application can be used in the root of the webserver.