### PR TITLE
fixes regression where compile can be very slow with large files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -697,43 +697,15 @@
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.15.0.tgz",
+      "integrity": "sha1-W0Q8oUK+jR22qMKuQvUZWLZrcPY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "requires": {
-            "core-js": "2.4.1",
-            "regenerator-runtime": "0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
-        }
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1049,7 +1021,6 @@
         "babel-plugin-transform-async-to-generator": "6.24.1",
         "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
         "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
         "babel-plugin-transform-es2015-classes": "6.24.1",
         "babel-plugin-transform-es2015-computed-properties": "6.24.1",
         "babel-plugin-transform-es2015-destructuring": "6.23.0",
@@ -2360,12 +2331,12 @@
       }
     },
     "eslint-config-qx": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/eslint-config-qx/-/eslint-config-qx-0.0.7.tgz",
-      "integrity": "sha1-59+aAY8EUtKlX3+9S4tY0OBie1s=",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-qx/-/eslint-config-qx-0.1.0.tgz",
+      "integrity": "sha512-fkQSBji7cwh63SuFoM1byJgO6ZWE2m1C0e8dwxEJy2S5RQrqFAIu7faU0Szi7Cub+bPPKlpVfIv3dfieaaAbYg==",
       "requires": {
         "eslint": "3.19.0",
-        "eslint-plugin-qx-rules": "0.0.2"
+        "eslint-plugin-qx-rules": "0.1.0"
       },
       "dependencies": {
         "ajv": {
@@ -2558,9 +2529,9 @@
       }
     },
     "eslint-plugin-qx-rules": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-qx-rules/-/eslint-plugin-qx-rules-0.0.2.tgz",
-      "integrity": "sha1-+rKwnkBiUZ7bVWLdMYuk83sel6U="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-qx-rules/-/eslint-plugin-qx-rules-0.1.0.tgz",
+      "integrity": "sha512-TmldxfvDvatPOtJxr1lFJsC0dTg3idZ3svQwRoR01zoZW7mJvBWxBGHeITUuH7qw9BcNPdyF4cV1fzUXejBvPg=="
     },
     "eslint-scope": {
       "version": "3.7.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "author": "John Spackman (johnspackman), Christian Boulanger (cboulanger), Henner Kollmann (hkollmann), and others",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "keywords": [
     "qooxdoo",
     "compiler",
@@ -39,6 +39,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-traverse": "^6.26.0",
     "babel-types": "^6.26.0",
+    "babel-plugin-transform-es2015-block-scoping": "6.15.0",
     "babylon": "^6.18.0",
     "chokidar": "^1.7.0",
     "columnify": "^1.5.4",


### PR DESCRIPTION
fixes a regression where newer versions of "babel-plugin-transform-es2015-block-scoping" are very slow, the fix is to lock the version number at 6.15;

this also increments the version number ready for the next npm release