### PR TITLE
fixes bug in typescript where spaces in function names (eg unit tests…

### DIFF
--- a/lib/qx/tool/compiler/targets/TypeScriptWriter.js
+++ b/lib/qx/tool/compiler/targets/TypeScriptWriter.js
@@ -220,7 +220,7 @@ qx.Class.define("qx.tool.compiler.targets.TypeScriptWriter", {
             comment += "Mixin ";
           if (methodMeta.overriddenFrom)
             comment += "Overridden from " + methodMeta.overriddenFrom + " ";
-          decl += name + "(";
+          decl += this.__escapeMethodName(name) + "(";
           decl += this.serializeParameters(methodMeta);
           decl += ")";
           
@@ -238,6 +238,18 @@ qx.Class.define("qx.tool.compiler.targets.TypeScriptWriter", {
           this.write(this.__indent + (hideMethod ? "// " : "") + decl + ";" + comment + "\n");
         }
       }
+    },
+    
+    /**
+     * Escapes the name with quote marks, only if necessary
+     * 
+     * @param name {String} the name to escape
+     * @return {String} the escaped (if necessary) name
+     */
+    __escapeMethodName: function(name) {
+      if (!name.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/))
+        return "\"" + name + "\"";
+      return name;
     },
     
     /**
@@ -313,7 +325,7 @@ qx.Class.define("qx.tool.compiler.targets.TypeScriptWriter", {
       this.write(" {\n");
       
       if (meta.type == "class")
-        this.writeConstructor(meta.constructor);
+        this.writeConstructor(meta.construct);
       this.writeMethods(meta.statics, meta, true);
       this.writeMethods(meta.members, meta);
       this.write("\n  }\n");


### PR DESCRIPTION
…) not copied through and constructor parameters missing

@FriedrichF