### PR TITLE
Fix for base

### DIFF
--- a/lib/qx/tool/compiler/files/Utils.js
+++ b/lib/qx/tool/compiler/files/Utils.js
@@ -59,7 +59,7 @@ qx.Class.define("qx.tool.compiler.files.Utils",{
             p = Promise.resolve();
           return p.then(() => {
             return readdir(from)
-              .then((files) => Promise.all(files.map((file) => t.sync(from + "/" + file, to + "/" + file))));
+              .then((files) => Promise.all(files.map((file) => t.sync(from + "/" + file, to + "/" + file, filter))));
           })
         } else if (statFrom.isFile()) {
           if (filter && !filter(from, to))

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -859,12 +859,16 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
       if (!t.isGenerateIndexHtml())
         return Promise.resolve();
       
+      var appRootDir;
+      var resDir;
       if (application.getWriteIndexHtmlToRoot()) {
         appRootDir = this.getOutputDir();
-        qx.tool.compiler.files.Utils.safeUnlink(appRootDir + t.getScriptPrefix() + "index.html");
+        resDir = this.getApplicationRoot(application);
+        qx.tool.compiler.files.Utils.safeUnlink(this.getApplicationRoot(application) + t.getScriptPrefix() + "index.html");
       } else {
         qx.tool.compiler.files.Utils.safeUnlink(this.getOutputDir() + t.getScriptPrefix() + "index.html");
         appRootDir = this.getApplicationRoot(application);
+        resDir = appRootDir;
       }
 
       function writeDefaultIndexHtml() {
@@ -900,15 +904,15 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
       if (!stats || !stats.isDirectory()) {
         return writeDefaultIndexHtml();
       }
-      await qx.tool.compiler.files.Utils.sync(bootDir, appRootDir, (from, to) => from != "index.html");
+      await qx.tool.compiler.files.Utils.sync(bootDir, resDir, (from, to) => from != "index.html");
       var stats = await stat(path.join(bootDir, "index.html"));
       if (stats.isFile()) {
         let html = await readFile(path.join(bootDir, "index.html"), { encoding: "utf8" });
         let str = "<script type=\"text/javascript\" src=\"" + t.getScriptPrefix() + "boot.js\"></script>\n</body>";
         let after = html.replace(/\<\/body\>/, str);
         if (application.getWriteIndexHtmlToRoot()) {
-          let str = "<base href=\"" + this.getProjectDir(application) + "/\" />\n</head>";
-          after = after.replace(/\<\/head\>/, str);
+          let str = "<head>\n<base href=\"" + this.getProjectDir(application) + "/\" />\n";
+          after = after.replace(/\<head\>/, str);
         }
         return writeFile(appRootDir + t.getScriptPrefix() + "index.html", after, { encoding: "utf8" });
       } else {

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -904,7 +904,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
       if (!stats || !stats.isDirectory()) {
         return writeDefaultIndexHtml();
       }
-      await qx.tool.compiler.files.Utils.sync(bootDir, resDir, (from, to) => from != "index.html");
+      await qx.tool.compiler.files.Utils.sync(bootDir, resDir, (from, to) => !from.endsWith("index.html"));
       var stats = await stat(path.join(bootDir, "index.html"));
       if (stats.isFile()) {
         let html = await readFile(path.join(bootDir, "index.html"), { encoding: "utf8" });


### PR DESCRIPTION
this pr fixes some minor Problems with writing index.html into root:

- found a little bug in sync with filter
- only index.html should live in base dir, all other stuff from boot dir must be in application dir because it's searched relative to application dir
