### PR TITLE
move database files into target output

### DIFF
--- a/lib/qx/tool/cli/commands/Clean.js
+++ b/lib/qx/tool/cli/commands/Clean.js
@@ -74,6 +74,8 @@ qx.Class.define("qx.tool.cli.commands.Clean", {
           });
         }
       }
+      // This isn't necessary after 0.2.9, except that it cleans up obsolete versions from
+      // older implementations
       for( let cacheFile of ["db.json","resource-db.json"]){
         let dbPath = path.join( process.cwd(), cacheFile );
         if( verbose ) console.info(`Removing ${cacheFile}...`);

--- a/lib/qx/tool/compiler/makers/Maker.js
+++ b/lib/qx/tool/compiler/makers/Maker.js
@@ -21,7 +21,7 @@
  * ************************************************************************/
 
 var fs = require("fs");
-var path = require("path");
+var path = require("upath");
 var async = require('async');
 require("qooxdoo");
 var util = require("../util");
@@ -170,7 +170,7 @@ module.exports = qx.Class.define("qx.tool.compiler.makers.Maker", {
      * @protected
      */
     _createAnalyser: function() {
-      var analyser = this._analyser = new (require("../Analyser"))(this.getDbFilename());
+      var analyser = this._analyser = new (require("../Analyser"))(path.join(this.getOutputDir(), (this.getDbFilename()||"db.json")));
       analyser.setOutputDir(this.getOutputDir());
       return analyser;
     },


### PR DESCRIPTION
the `db.json` and `resource-db.json` are specific to the target because of code elimination