### PR TITLE
Icon Font updates

### DIFF
--- a/docs/compiler/IconFonts.md
+++ b/docs/compiler/IconFonts.md
@@ -34,13 +34,13 @@ Use the *Manifest.json* to define the icon font like shown in the example:
       {
         "name": "FontAwesome",              // mandatory
         "defaultSize": 40,                  // optional
-        "mapping": "path_relative_to_project_root/fontawesome-map.json",   // optional - if you've a map file
+        "mapping": "project/fontawesome-map.json",   // optional - if you've a map file
         "comparisonString": "\uf26e\uf368", // string to test if font is loaded
         "resources": [
-          "path_relative_to_sources_resource/fontawesome-webfont.ttf",  // mandatory - we need one TTF file for parsing
-          "path_relative_to_sources_resource/fontawesome-webfont.eot",
-          "path_relative_to_sources_resource/fontawesome-webfont.woff2",
-          "path_relative_to_sources_resource/fontawesome-webfont.woff"
+          "project/fontawesome-webfont.ttf",  // mandatory - we need one TTF file for parsing
+          "project/fontawesome-webfont.eot",
+          "project/fontawesome-webfont.woff2",
+          "project/fontawesome-webfont.woff"
         ]
       }
     ]

--- a/docs/compiler/IconFonts.md
+++ b/docs/compiler/IconFonts.md
@@ -58,7 +58,7 @@ of "FontAwesome", you have to use `@Jipieh/<glyphname>` instead.
 The qooxdoo-compiler uses fontkit to read the content of the ttf file and will therefore
 automatically determine all the relevant css properties of the font, like fontFamily,
 fontWeight, fontStyle and even character names. For some icon fonts the character names are not properly
-stored or do may not match the names users expect to see based on popular css integrations of the font.
+stored or do not match the names users expect to see based on popular css integrations of the font.
 For these cases you you can provide a json fontmap file.
 
 ## Creating a map file

--- a/docs/compiler/IconFonts.md
+++ b/docs/compiler/IconFonts.md
@@ -8,7 +8,7 @@ Additionally we use the information placed in the font (glyph names) to automati
 assign the font icon to virtual image names. If you for example include the [Ligature Symbols](http://kudakurage.com/ligature_symbols/),
 you can directly use this code
 
-```
+```javascript
 var image = new qx.ui.basic.Image('@Ligature/print');
 ```
 
@@ -23,7 +23,7 @@ address all the glyphs by their name/alias.
 
 Use the *Manifest.json* to define the icon font like shown in the example:
 
-```
+```json
 {
   ...
 
@@ -68,9 +68,9 @@ we can't generate the mapping for you and you've to provide an own mapping.
 
 The format of the mapping file is just JSON as shown here:
 
-```
+```json
 {
-  "glyphname": : "hex-codepoint",
+  "glyphname": "hex-codepoint",
   ...
 }
 ```
@@ -104,42 +104,18 @@ for (let key in res) {
 
 After adding the fonts to the Manifest, they will automatically get loaded and integrated
 into your qooxdoo appliaction. It is not necessary to add a separate entry via en entry via 
-`qx.Theme.define` to load the font. Font theme entries are still required
-though for creating "pre-sized" variants of a font.
+`qx.Theme.define` to load the icon font. 
 
-like this in your theme's `Font.js`:
-
-```
-qx.Theme.define("foobar.theme.Font",
-{
-  extend : qx.theme.indigo.Font,
-
-  fonts :
-  {
-    "FontAwesome80": {
-      size: 80,
-      family: ["Font Awesome 5 Free"],
-    }
-  }
-});
-```
-
-Note also that the linkage to the font is via its 'real' name in the family entry and not via the name
-you chose for the font in the `Manifest.js`.
-
-## Using Iconfonts
-
-To include a font icon somewhere, just use the ordinary image way (i.e. in an Image, Atom) and
-provide a virtual image name. It starts with an "@", followed by the defined font name, a slash
+The font icons can now be used in qooxdoo image widgets like Image or Atom. Just start the image name with a `@`, followed by the defined font name, a slash
 and the glyph name:
 
-```
+```javascript
 var atom = new qx.ui.basic.Atom("Look, I'm a font icon", "@FontAwesome/heart");
 ```
 
 If you don't have a glyph name (no map file and no definition in the font), you can also use the
 unicode codepoint (in hex) directly:
 
-```
+```javascript
 var atom = new qx.ui.basic.Atom("Look, I'm a font icon", "@FontAwesome/f004");
 ```

--- a/docs/compiler/IconFonts.md
+++ b/docs/compiler/IconFonts.md
@@ -23,7 +23,7 @@ address all the glyphs by their name/alias.
 
 Use the *Manifest.json* to define the icon font like shown in the example:
 
-```json
+```json5
 {
   ...
 
@@ -68,7 +68,7 @@ we can't generate the mapping for you and you've to provide an own mapping.
 
 The format of the mapping file is just JSON as shown here:
 
-```json
+```json5
 {
   "glyphname": "hex-codepoint",
   ...

--- a/docs/compiler/IconFonts.md
+++ b/docs/compiler/IconFonts.md
@@ -1,4 +1,4 @@
-# Using Icon Fonts
+# Icon Fonts
 
 Icon fonts in qooxdoo need some preprocessing, because the layout managers need to know the
 dimensions of 'images'. In this case, we're extracting this information from the glyph's

--- a/lib/qx/tool/compiler/app/WebFont.js
+++ b/lib/qx/tool/compiler/app/WebFont.js
@@ -53,15 +53,25 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
       init: 40
     },
 
-    /** Optional mapping filename */
+    /** 
+     * Optional mapping filename. The path is relative to the location of the
+     * `Manifest.json` file. The mapping file is in json format and should contain
+     * a map of icon name to code point in hex: 
+     * `{ "my_icon": "ef99", "my_other_icon": "483c"}` 
+     */
     mapping: {
       init: null,
       nullable: true,
       check: "String"
     },
 
-    /** Optional characters to be used for the 'is it loaded' test */
-    testCharacters: {
+    /** 
+     * Characters that are used to test if the font has loaded properly. These
+     * default to "WEei" in `qx.bom.webfont.Validator` and can be overridden
+     * for certain cases like icon fonts that do not provide the predefined
+     * characters.
+     */
+    comparisonString: {
       init: null,
       nullable: true,
       check: "String"
@@ -220,8 +230,8 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
         ]
       };
 
-      if (this.getTestCharacters()) {
-        font.comparisonString = this.getTestCharacters();
+      if (this.getComparisonString()) {
+        font.comparisonString = this.getComparisonString();
       }
 
       return res += "qx.$$fontBootstrap['" + this.getName() + "']=" + JSON.stringify(font) + ";";

--- a/lib/qx/tool/compiler/app/WebFont.js
+++ b/lib/qx/tool/compiler/app/WebFont.js
@@ -177,11 +177,17 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
   
             let map = JSON.parse(data);
             Object.keys(map).forEach((key) => {
-              let glyph = font.glyphForCodePoint(map[key]);
+              let codePoint = parseInt(map[key],16);
+              let glyph = font.glyphForCodePoint(codePoint);
+              if (!glyph.id) {
+                console.log(`WARN: no glyph found for ${font} ${key}: ${codePoit}`);
+                return;
+              }
+              let bbox = glyph.path.bbox;
               resources["@" + this.getName() + "/" + key] = [
                 this.getDefaultSize(),
-                Math.round(this.getDefaultSize() * glyph.advanceHeight / glyph.advanceWidth),
-                parseInt(map[key], 16)
+                Math.round(this.getDefaultSize() * bbox.width / bbox.height),
+                codePoint
               ];
             })
   
@@ -193,9 +199,10 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
 
         font.characterSet.forEach(function(codePoint) {
           let glyph = font.glyphForCodePoint(codePoint);
+          let bbox = glyph.path.bbox;
           resources["@" + this.getName() + "/" + glyph.name] = [
             this.getDefaultSize(),
-            Math.round(this.getDefaultSize() * glyph.advanceHeight / glyph.advanceWidth),
+            Math.round(this.getDefaultSize() * bbox.width / bbox.height),
             codePoint
           ];
         }, this);

--- a/lib/qx/tool/compiler/app/WebFont.js
+++ b/lib/qx/tool/compiler/app/WebFont.js
@@ -165,12 +165,13 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
 
         let resources = {};
 
-        // If we've a mapping file, take this information instead
+        // If we have a mapping file, take this information instead
         // of anaylzing the font.
         if (this.getMapping()) {
-          fs.readFile(this.getMapping(), {encoding: 'utf-8'}, (err, data) => {
+          let mapPath = path.join(this.__library.getResourcePath(),this.getMapping());
+          fs.readFile(mapPath, {encoding: 'utf-8'}, (err, data) => {
             if (err) {
-              log.error(`Cannot read mapping file '${this.getMapping()}': ${err.code}`);
+              log.error(`Cannot read mapping file '${mapPath}': ${err.code}`);
               return reject(err);
             }
   


### PR DESCRIPTION
* replace `testCharacters` with the qooxdoo standard `comparisonString`
* make font-map path work relative to the resource directory same as the fonts
* properly request glyphes with decimal codepoints
* use bbox glyph sizing
* add documentation

since `testCharacters` has not been documented at all, I don't see a problem with the missing backward compatibility.