### PR TITLE
webfont fixes and better documentation

### DIFF
--- a/lib/qx/tool/compiler/app/WebFont.js
+++ b/lib/qx/tool/compiler/app/WebFont.js
@@ -53,15 +53,25 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
       init: 40
     },
 
-    /** Optional mapping filename */
+    /**
+     * Optional mapping filename. The path is relative to the location of the
+     * `Manifest.json` file. The mapping file is in json format and should contain
+     * a map of icon name to code point in hex:
+     * `{ "my_icon": "ef99", "my_other_icon": "483c"}`
+     */
     mapping: {
       init: null,
       nullable: true,
       check: "String"
     },
 
-    /** Optional characters to be used for the 'is it loaded' test */
-    testCharacters: {
+    /**
+     * Characters that are used to test if the font has loaded properly. These
+     * default to "WEei" in `qx.bom.webfont.Validator` and can be overridden
+     * for certain cases like icon fonts that do not provide the predefined
+     * characters.
+     */
+    comparisonString: {
       init: null,
       nullable: true,
       check: "String"
@@ -155,25 +165,31 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
 
         let resources = {};
 
-        // If we've a mapping file, take this information instead
+        // If we have a mapping file, take this information instead
         // of anaylzing the font.
         if (this.getMapping()) {
-          fs.readFile(this.getMapping(), {encoding: 'utf-8'}, (err, data) => {
+          let mapPath = path.join(this.__library.getResourcePath(),this.getMapping());
+          fs.readFile(mapPath, {encoding: 'utf-8'}, (err, data) => {
             if (err) {
-              log.error(`Cannot read mapping file '${this.getMapping()}': ${err.code}`);
+              log.error(`Cannot read mapping file '${mapPath}': ${err.code}`);
               return reject(err);
             }
-  
+
             let map = JSON.parse(data);
             Object.keys(map).forEach((key) => {
-              let glyph = font.glyphForCodePoint(map[key]);
+              let codePoint = parseInt(map[key],16);
+              let glyph = font.glyphForCodePoint(codePoint);
+              if (!glyph.id) {
+                console.log(`WARN: no glyph found for ${font} ${key}: ${codePoit}`);
+                return;
+              }
               resources["@" + this.getName() + "/" + key] = [
-                this.getDefaultSize(),
-                Math.round(this.getDefaultSize() * glyph.advanceHeight / glyph.advanceWidth),
-                parseInt(map[key], 16)
+                Math.ceil(this.getDefaultSize() * glyph.advanceWidth / glyph.advanceHeight), // width
+                this.getDefaultSize(), // height
+                codePoint
               ];
-            })
-  
+            }, this);
+
             return resolve(resources);
           });
 
@@ -182,9 +198,10 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
 
         font.characterSet.forEach(function(codePoint) {
           let glyph = font.glyphForCodePoint(codePoint);
+          let bbox = glyph.path.bbox;
           resources["@" + this.getName() + "/" + glyph.name] = [
-            this.getDefaultSize(),
-            Math.round(this.getDefaultSize() * glyph.advanceHeight / glyph.advanceWidth),
+            Math.ceil(this.getDefaultSize() * glyph.advanceWidth / glyph.advanceHeight), // width
+            this.getDefaultSize(), // height
             codePoint
           ];
         }, this);
@@ -203,7 +220,7 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
      */
     getBootstrapCode : function(target, application, initial) {
       let res = "";
-      
+
       if (initial) {
         res = "qx.$$fontBootstrap={};\n";
       }
@@ -220,8 +237,8 @@ qx.Class.define("qx.tool.compiler.app.WebFont", {
         ]
       };
 
-      if (this.getTestCharacters()) {
-        font.comparisonString = this.getTestCharacters();
+      if (this.getComparisonString()) {
+        font.comparisonString = this.getComparisonString();
       }
 
       return res += "qx.$$fontBootstrap['" + this.getName() + "']=" + JSON.stringify(font) + ";";


### PR DESCRIPTION
my second attempt

* the font 'height' is classicly associated with the size, so when giving with and height of the font, associate the size with the height
* use a resource relative path for font maps
* complain if non-existing codepoints are referenced in the fontmap
* codepoints in maps are hex, but fontkit expects them in decimal ... adapt accordingly
* updated documentation
* `testCharacters` should be called `comparisonString`