### PR TITLE
Remove node sass from packages-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4518,43 +4518,6 @@
         }
       }
     },
-    "node-sass": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
-      "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
-      "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.1",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.10.0",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.79.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0",
-        "true-case-path": "1.0.2"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-          "requires": {
-            "lru-cache": "4.1.3",
-            "which": "1.3.0"
-          }
-        }
-      }
-    },
     "nomnom": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "json-to-ast": "https://github.com/johnspackman/json-to-ast.git#editable-json",
     "jsonlint": "^1.6.2",
     "node-fetch": "^1.7.3",
-    "node-sass": "^4.7.2",
+    "node-sass": "^4.9.0",
     "qooxdoo": "^5.0.1",
     "@qooxdoo/preset-env": "^1.0.0",
     "qooxdoo-sdk": "^6.0.0-alpha",


### PR DESCRIPTION
on further investigation ... we can't do anything about hoek directly ... since node-sass is requiring that old version ... but we can at least not require people to use the vulnerable version of hoek by listing it in our package-lock file.