### PR TITLE
make --set more liberal

### DIFF
--- a/docs/cli/compiler.md
+++ b/docs/cli/compiler.md
@@ -16,6 +16,7 @@ Options:
   --write-all-translations  enables output of all translations, not just those
                             that are explicitly referenced             [boolean]
   --set                     sets an environment value                    [array]
+			    key="value" (with value getting evaluated as js)
   --app-class               sets the application class                  [string]
   --app-theme               sets the theme class for the current application
                                                                         [string]

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -22,6 +22,7 @@ Options:
   --write-all-translations  enables output of all translations, not just those
                             that are explicitly referenced             [boolean]
   --set                     sets an environment value                    [array]
+                            key="value" (with value getting evaluated as js)
   --machine-readable        output compiler messages in machine-readable format
                                                                        [boolean]
   --verbose, -v             enables additional progress output to console

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -174,11 +174,11 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
             try {
               result.environment[key] = Function('"use strict";return (' + value + ')')();
             } catch (error) {
-              console.error("Failed to translate environment value '"+value+"' to a js datatype - "+error)
+              throw new Error("Failed to translate environment value '"+value+"' to a js datatype - "+error)
             }
           }
           else {
-            console.log("Failed to parse environment setting commandline option '"+kv+"'");
+            throw new Error("Failed to parse environment setting commandline option '"+kv+"'");
           }
         });
       }

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -167,11 +167,18 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
       };
       if (argv.set) {
         argv.set.forEach(function(kv) {
-          var m = kv.match(/^([a-z0-9_]+)(=(.*))?$/);
+          var m = kv.match(/^([^=\s]+)(=(.+))?$/);
           if (m) {
             var key = m[1];
             var value = m[3];
-            result.environment[key] = value;
+            try {
+              result.environment[key] = Function('"use strict";return (' + value + ')')();
+            } catch (error) {
+              console.error("Failed to translate environment value '"+value+"' to a js datatype - "+error)
+            }
+          }
+          else {
+            console.log("Failed to parse environment setting commandline option '"+kv+"'");
           }
         });
       }


### PR DESCRIPTION
* be more liberal in accepting names for qx environment variables via the --set option. Now everything but space and = are allowed in the names.
* parse the value as js expression.