### PR TITLE
Always use the latest npm qooxdoo version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "node-fetch": "^1.7.3",
     "node-sass": "^4.9.0",
     "qooxdoo": "^5.0.1",
-    "qooxdoo-sdk": "^6.0.0-alpha",
+    "qooxdoo-sdk": ">6.0.0-alpha",
     "rimraf": "^2.6.2",
     "semver": "^5.3.0",
     "tmp": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "node-fetch": "^1.7.3",
     "node-sass": "^4.9.0",
     "qooxdoo": "^5.0.1",
-    "qooxdoo-sdk": ">6.0.0-alpha",
+    "qooxdoo-sdk": "6.* || >6.0.0-alpha",
     "rimraf": "^2.6.2",
     "semver": "^5.3.0",
     "tmp": "0.0.33",


### PR DESCRIPTION
change qooxdoo-sdk version so that the newest alpha version will be used.