### PR TITLE
Improved markdown to render titles and references to code

### DIFF
--- a/docs/compiler/API.md
+++ b/docs/compiler/API.md
@@ -8,32 +8,37 @@ The API has these core concepts:
 * Maker
 
 ## Library (qxcompiler.Library)
-A Library is a collection of code, in a namespace with a Manifest.json - i.e. this is exactly the same as generate.py 
+
+A Library is a collection of code, in a namespace with a Manifest.json - i.e. this is exactly the same as generate.py
 sees the concept of a Library.
 
-Note that your application is also a Library - it has a namespace, classes in JS files, and a Manifest.json; both 
+Note that your application is also a Library - it has a namespace, classes in JS files, and a Manifest.json; both
 QxCompiler and generate.py see these as just libraries.  You know that one of the classes in your library is the
 main "Application" class but QxCompiler just sees a library.
 
-## Application (qxcompiler.Application)
+## Application (``qxcompiler.Application``)
+
 An Application, in QxCompiler terms, is something that you want QxCompiler *to create*, which can be downloaded by
-a web browser and run.  An Application primarily consists of the application class (eg possibly derived from 
-qx.application.Standalone) and a theme; the QxCompiler will scan the Libraries looking for these classes and gathering
+a web browser and run.  An Application primarily consists of the application class (e.g. possibly derived from
+``qx.application.Standalone``) and a theme; the QxCompiler will scan the Libraries looking for these classes and gathering
 their dependency information until it has a complete set of classes to output.
 
-## Target (qxcompiler.targets.*)
-When creating an Application, QxCompiler assembles the code according to a Target - currently these are SourceTarget, 
+## Target (``qxcompiler.targets.*``)
+
+When creating an Application, QxCompiler assembles the code according to a Target - currently these are SourceTarget,
 BuildTarget, and HybridTarget and they correspond to the "build", "source" and "source-hybrid" targets in generate.py.
 
-## Maker (qxcompiler.makers.*)
+## Maker (``qxcompiler.makers.*``)
+
 The process of analysing code and assembling Applications is typically controlled by a Maker; all this does is control
 loading the dependency database, scanning Library's, and instructing the Target to output the Application.
 
-For most apps the qxcompiler.makers.SimpleApp will be sufficient, but some applications are more involved - for example,
-the DemoBrowser is actually a set of 222 Applications as well as the main DemoBrowser app, and the qxcompiler.makers.DemoBrowserApp
+For most apps the ``qxcompiler.makers.SimpleApp`` will be sufficient, but some applications are more involved - for example,
+the DemoBrowser is actually a set of 222 Applications as well as the main DemoBrowser app, and the ``qxcompiler.makers.DemoBrowserApp``
 class takes care of "making" all 223 Applications.
 
-## Resources (qxcompiler.resources.*)
-Analysing resources is controlled by `qxcompiler.resources.Manager`, it scans the `resources` directory of each Library and compiles a database of what's available.  Along the way, it analyses the files according to the file extension - for images, it finds the width and height to add to the database, and for .meta files it incorporates the sprite data into the database.
+## Resources (``qxcompiler.resources.*``)
+
+Analysing resources is controlled by ``qxcompiler.resources.Manager``, it scans the `resources` directory of each Library and compiles a database of what's available.  Along the way, it analyses the files according to the file extension - for images, it finds the width and height to add to the database, and for .meta files it incorporates the sprite data into the database.
 
 Adding support for a new file is easy - derive a class from `qxcompiler.resources.Handler` and add it to the array in the constructor for `qxcompiler.resources.Manager`.

--- a/docs/compiler/CustomAppStartup.md
+++ b/docs/compiler/CustomAppStartup.md
@@ -4,8 +4,7 @@ By default, the compiler will output a standard `index.html` into the applicatio
 
 If you just want to change the title of the application web page, the easier way to do it is set the title on the Application object - if you're using the compiler API, see the `title` property of `qxcompiler.app.Application`, but if you're using `qx` command line tool modify your `compile.json` to look like this:
 
-```
-`
+```json
 {
     /** Applications */
     "applications": [
@@ -20,7 +19,7 @@ If you just want to change the title of the application web page, the easier way
 
 If you want to customise this further, you can replace the `index.html` with your own version by adding a template directory to your `Manifest.json` - in the `provides` object, add a new entry `boot` which contains the path to the directory (which is normally `"source/boot"`), for example:
 
-```
+```json
     {
         "provides": {
             "namespace": "demoapp",
@@ -40,21 +39,25 @@ To customise the index.html which is generated, create a file called `boot/index
 
 
 # Splash Screens
-** NOTE ** It's fair to say that this is still a work in progress - although this treatment for SplashScreens works just fine, it is only able to update the UI as each individual script loads, which means that for a `build` target, nothing will appear because there is only one script file.
+
+**NOTE** It's fair to say that this is still a work in progress - although this treatment for SplashScreens works just fine, it is only able to update the UI as each individual script loads, which means that for a `build` target, nothing will appear because there is only one script file.
 
 Splash screens are an optional feature of the application loader in `qooxdoo-compiler` that will provide an attractive feedback with a progress bar all the way through your application's startup.
 
 By default, the loader does not provide any splash screen or progress bar; to add one, you need to replace the application's `.html` file with your own, and provide a global object called `QOOXDOO_SPLASH_SCREEN` that the boot loader can call during the boot process.
 
 ## Loading Speed
+
 Splash screens will slow down the load fractionally, but only in the order of 100-200ms.  It's important to remember that loading speed is subjective, and as a developer the progress bar emphasises an unnecessary slow down of the load, whereas to a user a blank screen emphasises waiting for startup.  But if you measure it, the difference in time is negligable.
 
 The new loader supports URL query parameters which allow you to customise the startup to fine tune or eliminate the boot loader so that you can time various different approaches.  If you have installed a boot loader, try appending `?qooxdoo:feedback-disable=true` to your application's URL and comparing boot times.  For more information on loader URLs, see [qooxdoo-compiler/docs/LoaderUrls.md](https://github.com/qooxdoo/qooxdoo-compiler/blob/master/docs/LoaderUrls.md)
 
 ## Example
+
 For a working example, take a look at [qooxdoo-compiler/demos/boot/](https://github.com/qooxdoo/qooxdoo-compiler/tree/master/demos/boot/) - if you add this folder to your application's `source` folder and re-run `qx compile`, it will have a splash screen with loading progress bar.
 
 ## Chunking
+
 Previously, the only option for loading scripts was either asynchronously (also called "parallel" loading) or not.  Asynchronous loading queues all scripts to be loaded by the browser (which could be hundreds thousands) and allows the browser to go ahead and load as fast as possible.  For splash screens this is not ideal because the browser is working so hard at loading scripts that it does not redraw the display with any updated progress information, so from the point of view of the user the progress bar will be stuck at a low number until the application is suddenly running.
 
 To solve this, chunking (enabled by default *only if* there a `QOOXDOO_SPLASH_SCREEN` object) divides the list of scripts to load into "chunks" and adds a small 1ms timeout between each chunk to allow the browser to redraw the screen.  This slows the loading because of the 1ms delay and the time it takes to redraw, but on the other hand your user will get feedback all the way through the load.
@@ -65,23 +68,23 @@ By default the chunks are 20% of the total number of scripts, but you can overri
 
 `QOOXDOO_SPLASH_SCREEN` is a plain Javascript object that looks like this:
 
-```
+```javascript
   window.QOOXDOO_SPLASH_SCREEN = {
     loadBegin: function(callback) {
       /* ... snip ... */
       callback();
     },
-    
+
     loadComplete: function(callback) {
       /* ... snip ... */
       callback();
     },
-    
+
     scriptLoaded: function(options, callback) {
       /* ... snip ... */
       callback();
     },
-    
+
     getSettings: function() {
       /* ... snip ... */
       return null;
@@ -93,19 +96,22 @@ By default the chunks are 20% of the total number of scripts, but you can overri
 The `options` parameter has a `command` property (e.g. `"script-loaded"`) that determines what the other properties of the object will be.
 
 ### `loadBegin(callback)`
-This is fired immediately before scripts start to be loaded; `callback()` must be called at the end (script loading will not begin until it has been called) 
+
+This is fired immediately before scripts start to be loaded; `callback()` must be called at the end (script loading will not begin until it has been called)
 
 ### `loadComplete(callback)`
-This is fired when all scripts are loaded and the application is about to startup; `callback()` must be called at the end (the application will not start until it has been called) 
+
+This is fired when all scripts are loaded and the application is about to startup; `callback()` must be called at the end (the application will not start until it has been called)
 
 ### `scriptLoaded(options, callback)`
+
 This is fired every time a script completes loading, and has these properties in `options`:
 - `numScripts` - total number of scripts to load
 - `numScriptsLoaded` - number of scripts fully loaded so far
 - `numScriptsLoading` - number of scripts in progress
 
 ### `getSettings()`
+
 This is called once before any scripts are loaded to allow the loader to override default settings.  The result can be null, or an object which has these properties:
 - `isLoadChunked` - (**optional**) whether to load scripts in "chunks"
 - `loadChunkSize` - (**optional**) if loading with chunks, how big each chunk should be (default is 20% of the number of scripts)
-

--- a/docs/compiler/Dependencies.md
+++ b/docs/compiler/Dependencies.md
@@ -1,8 +1,8 @@
-#Dependencies
+# Dependencies
 
 The main task of QxCompiler (and generate.py) is to read the code and figure out the correct load order for the javascript
 files.  Once you have a parser and can recognise symbol references it is quite straightforward to determine what classes
-are required, but the order in which they must be loaded is more complex because if you simply assume that any reference 
+are required, but the order in which they must be loaded is more complex because if you simply assume that any reference
 means the class referred must be loaded first then you quickly find a recursive dependency order that cannot be satisfied.
 
 Consider this example:
@@ -11,59 +11,62 @@ Consider this example:
 qx.Class.define("mypackage.MyClassA", {
     extend: qx.core.Object,
     implement: [ qx.data.IListData ],
-    
+
     members: {
         someMethod: function() {
             new qx.data.Array();
         }
     },
-    
+
     statics: {
         IS_MSIE: qx.core.Environment.get("engine.name") == "mshtml"
     }
 });
 ```
 
-In this example, qx.data.Array is required *at runtime* but is not required to load the class - the load dependencies are
-any class referred to directly by the object passed to qx.Class.define.  Note the call to qx.core.Environment.get - it
-uses the "engine.name" check which is implemented by qx.bom.client.Engine, so there is another load time dependency there.
+In this example, ``qx.data.Array`` is required *at runtime* but is not required to load the class - the load dependencies are
+any class referred to directly by the object passed to ``qx.Class.define``.  Note the call to ``qx.core.Environment.get`` - it
+uses the ``"engine.name"`` check which is implemented by ``qx.bom.client.Engine``, so there is another load time dependency there.
 
-##Class .defer() method
+## Class .defer() method
+
 All of the above can be done with fairly simple static analysis, but there is a further difficulty - each class definition
-can have a defer() method which is called immediately after the class has been defined; because the code in defer() can
-do anything, it can add significant dependencies which can only be determined by recursively interpreting the code in .defer()
-and all of the methods it calls, ie predicting at compile-time what methods will be called at runtime so that it can make
+can have a ``defer()`` method which is called immediately after the class has been defined; because the code in ``defer()`` can
+do anything, it can add significant dependencies which can only be determined by recursively interpreting the code in ``.defer()``
+and all of the methods it calls, i.e. predicting at compile-time what methods will be called at runtime so that it can make
 sure that the load order is correct.
 
-For example, qx.ui.form.AbstractField.defer() calls qx.ui.style.Stylesheet.getInstance(), the constructor for which calls 
-qx.bom.Stylesheet.createElement(); that function in turns relies on the "html.stylesheet.createstylesheet" environment check 
-which is implemented by qx.bom.client.Stylesheet.  So technically, qx.ui.form.AbstractField has a load time dependency on 
-qx.bom.client.Stylesheet but this can only be identified by tracking the dependencies on a per function basis, 
+For example, ``qx.ui.form.AbstractField.defer()`` calls ``qx.ui.style.Stylesheet.getInstance()``, the constructor for which calls
+``qx.bom.Stylesheet.createElement()``; that function in turn relies on the ``"html.stylesheet.createstylesheet"`` environment check
+which is implemented by ``qx.bom.client.Stylesheet``.  So technically, ``qx.ui.form.AbstractField`` has a load time dependency on
+``qx.bom.client.Stylesheet`` but this can only be identified by tracking the dependencies on a per function basis,
 recursively scanning code and statically determining what the runtime dependencies *would* be.
 
-I guess that this is something that generate.py does, but it makes dependency analysis hugely more complex and is quite
-fragile - it would be very easy for the author of qx.bom.Stylesheet to make a minor change in the constructor 
+I guess that this is something that ``generate.py`` does, but it makes dependency analysis hugely more complex and is quite
+fragile - it would be very easy for the author of ``qx.bom.Stylesheet`` to make a minor change in the constructor
 and introduce a recursive, unresolvable dependency.
- 
-However this is only an issue for loading the class, if we can avoid calling defer() until all the classes have been loaded
+
+However this is only an issue for loading the class, if we can avoid calling ``defer()`` until all the classes have been loaded
 then the problem disappears; this is the solution used by QxCompiler in almost all cases.  It's important to note that
-a class is not fully defined until it's defer method has been called, so the exception is that any class methods which 
-are called when defining a class (such as qx.core.Environment.get()) must make sure that the defer() method has already been
-called for that class.  In the above example, this means that mypackage.MyClassA must have q.core.Environment loaded *and* it's
-defer method called before the call to qx.Class.define("mypackage.MyClassA"...).
+a class is not fully defined until it's ``defer`` method has been called, so the exception is that any class methods which
+are called when defining a class (such as ``qx.core.Environment.get()``) must make sure that the ``defer()`` method has already been
+called for that class.  In the above example, this means that ``mypackage.MyClassA`` must have ``q.core.Environment`` loaded *and* it's
+defer method called before the call to ``qx.Class.define("mypackage.MyClassA"...)``.
 
-##Is this backward compatible?
-Mostly - if you have code in a classs's .defer() method which calls methods that refer to other classes, you may find that
+## Is this backward compatible?
+
+Mostly - if you have code in a class's ``.defer()`` method which calls methods that refer to other classes, you may find that
 your code breaks; this will only happen if that code is required to load another class though, so this is really quite
-rare.  The typical example in Qooxdoo itself is environment checks, which are often needed at a fairly low level before 
-all classes are loaded, but do have dependencies caused by indirect calls from .defer().  
+rare.  The typical example in Qooxdoo itself is environment checks, which are often needed at a fairly low level before
+all classes are loaded, but do have dependencies caused by indirect calls from ``.defer()``.  
 
-If you find that you have code which is called via a class's .defer() method and there is an unsatisfied dependency, the
-solution is to add an @require at the top of your code to let QxCompiler know that your class will need it.  This is 
-fairly rare though - the entire Qooxdoo library only needed 6 additonal @require statements, to add to the 269 that were
+If you find that you have code which is called via a class's ``.defer()`` method and there is an unsatisfied dependency, the
+solution is to add an ``@require`` at the top of your code to let QxCompiler know that your class will need it.  This is
+fairly rare though - the entire Qooxdoo library only needed 6 additonal ``@require`` statements, to add to the 269 that were
 already in use.
 
 
-##Runtime meta data
-The meta data about a class, it's dependencies, unresolved symbols, etc are available as a static object $$dbClassInfo for 
-each class, EG mypackage.MyClassA.$$dbClassInfo.  Much of this will probably be stripped out in future build targets.
+## Runtime meta data
+
+The meta data about a class, it's dependencies, unresolved symbols, etc are available as a static object ``$$dbClassInfo`` for
+each class, e.g. ``mypackage.MyClassA.$$dbClassInfo``.  Much of this will probably be stripped out in future build targets.

--- a/docs/compiler/LoaderUrls.md
+++ b/docs/compiler/LoaderUrls.md
@@ -1,4 +1,5 @@
 # Loader URLs
+
 The application loader in `qooxdoo-compiler` will run automatically without any additional parameters, but there are some query parameters which you can add to adjust the boot process.
 
 They are:

--- a/docs/compiler/MetaData.md
+++ b/docs/compiler/MetaData.md
@@ -10,7 +10,7 @@ Another useful feature is that when documentation is missing for a method or pro
 
 Many of the objects in the meta data have a set of standard, useful fields; for example:
 
-```
+```json
   "methods": {
     "_createOkButton": {
       "location": {
@@ -61,7 +61,8 @@ The `location` and `jsdoc` objects appear in just about every meta data object; 
 ## Class Definition
 
 A typical meta data example looks like this:
-```
+
+```json
 {
   "className": "myapp.some.package.MyClass",
   "packageName": "myapp.some.package",


### PR DESCRIPTION
Some fixes in markdown format I did while reading the docs. Now docs/compiler/ pages are nicely rendered in github.