### PR TITLE
Catch problems in Manifest.json

### DIFF
--- a/lib/qx/tool/compiler/app/Library.js
+++ b/lib/qx/tool/compiler/app/Library.js
@@ -140,13 +140,13 @@ qx.Class.define("qx.tool.compiler.app.Library", {
         
         try {
           data = jsonlint.parse(data);
-        }catch(ex) {
+          t.setNamespace(data.provides.namespace);
+          var sourcePath = data.provides["class"];
+          t.setSourcePath(sourcePath);
+          t.setResourcePath(data.provides.resource);
+        } catch(ex) {
           return cb && cb(new Error("Cannot parse " + rootDir + "/Manifest.json: " + ex));
         }
-        t.setNamespace(data.provides.namespace);
-        var sourcePath = data.provides["class"];
-        t.setSourcePath(sourcePath);
-        t.setResourcePath(data.provides.resource);
         if (data.provides.transpiled)
           t.setTranspiledPath(data.provides.transpiled);
         else {


### PR DESCRIPTION
This will create a more meaningful error message if a `Manifest.json`'s require section has problems. 