### PR TITLE
Fixes #198 #156

### DIFF
--- a/lib/qx/tool/cli/commands/contrib/Publish.js
+++ b/lib/qx/tool/cli/commands/contrib/Publish.js
@@ -23,7 +23,7 @@ require("../Contrib");
 require("qooxdoo");
 const fs = require("fs");
 const process = require('process');
-const Repository = require('github-api/dist/components/Repository');
+const octokit = require('@octokit/rest')();
 const jsonlint = require("jsonlint");
 const semver = require("semver");
 const inquirer = require("inquirer");
@@ -33,7 +33,6 @@ const ENV_GH_ACCESS_TOKEN = "GITHUB_ACCESS_TOKEN";
 
 /**
  * Publishes a release on GitHub
- * @todo add GitHub topic "qooxdoo-contrib" to repository (not yet availaible via API)
  */
 qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
   extend: qx.tool.cli.commands.Contrib,
@@ -103,6 +102,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
      * 2. In Manifest.json, based the given options, increment the version number (patch, 
      *    feature, breaking). 
      * 3. Create a release with the tag vX.Y.Z according to the current version.
+     * 4. Add "qooxdoo-contrib" to the list of GitHub topics.
      * 
      */
     process: async function() {
@@ -130,6 +130,10 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
       if( ! token ){
         throw new qx.tool.cli.Utils.UserError(`GitHub access token required. Pass it via --token or set the environment variable ${ENV_GH_ACCESS_TOKEN}`);
       }
+      octokit.authenticate({
+        type: 'token',
+        token
+      });
 
       // read Manifest.json
       let manifest_path = process.cwd() + "/Manifest.json";
@@ -158,6 +162,38 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
           throw new qx.tool.cli.Utils.UserError("Invalid version number in Manifest. Must be a valid semver version (x.y.z).");
         }
         new_version = semver.inc( old_version, argv.type );
+      }
+
+      // tag and repo name
+      let tag = `v${new_version}`;
+      let url;
+      try {
+        url = (await this.exec("git config --get remote.origin.url")).trim();
+      } catch(e) {
+        throw new qx.tool.cli.Utils.UserError("Cannot determine remote repository.");
+      }
+      let repo_name   = url.replace(/(https:\/\/github.com\/|git@github.com:)/,"").replace(/\.git/,"");
+      let [owner,repo] = repo_name.split(/\//);
+      if(argv.verbose) {
+        console.log(`>>> Repository:  ${repo_name}`);
+      }
+      let repoExists = false;
+      try{
+        const result = await octokit.repos.getReleaseByTag({owner, repo, tag});
+        repoExists = true;
+      } catch(e) {}
+      if (repoExists) throw new qx.tool.cli.Utils.UserError(`A release with tag '${tag} already exists.'`);
+
+      // get topics, this will also check credentials
+      let result, topics;
+      try {
+        result = await octokit.repos.getTopics({owner, repo});
+        topics = result.data.names;
+      } catch (e) {
+        if ( e.message.includes("Bad credentials") ){
+          throw new qx.tool.cli.Utils.UserError(`Your token is invalid.`);
+        }
+        throw e;
       }
 
       // prompt user to confirm
@@ -193,18 +229,9 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
       if ( ! argv.dryrun ) {
         fs.writeFileSync( manifest_path, manifest_content, "utf-8");
       }
-      
-      // tag name
-      let url, repo_name, tag_name;
-      try {
-        url = await this.exec("git config --get remote.origin.url");
-      } catch(e) {
-        this.exit("Cannot determine remote repository.");
-      }
-      repo_name = url.replace(/https:\/\/github.com\//,"").replace(/\.git/,"").trim();
-      tag_name = `v${new_version}`;
+
       if ( argv.dryrun ) {
-        if( ! argv.quiet) console.info(`Dry run: not creating tag and release '${tag_name}' of ${repo_name}...`);
+        if( ! argv.quiet) console.info(`Dry run: not creating tag and release '${tag}' of ${repo_name}...`);
         console.info( "Here is the Manifest.json that would have been committed: ");
         console.info(manifest_content);
         process.exit(0);
@@ -228,7 +255,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
       }
       
       if( ! argv.quiet ) {
-        console.info(`Creating tag and release '${tag_name}' of ${repo_name}...`);
+        console.info(`Creating tag and release '${tag}' of ${repo_name}...`);
       } 
 
       // commit and push
@@ -237,17 +264,30 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
         await this.run("git",["commit",`-m "${message}"`]);
         await this.run("git",["push"]);
         let release_data = {
-          tag_name,
-          "target_commitish": "master",
-          "name": tag_name,
-          "body": ``,
-          "draft": false,
-          "prerelease": (argv.type.indexOf("pre")>=0)
+          owner,
+          repo,
+          tag_name: tag,
+          target_commitish: "master",
+          name: tag,
+          body: message,
+          draft: false,
+          prerelease: (argv.type.indexOf("pre")>=0)
+        };
+        await octokit.repos.createRelease(release_data);
+        if( ! argv.quiet ) {
+          console.info(`Published new version '${tag}'.`);
         }
-        let repository = new Repository(repo_name, {token} ); 
-        await repository.createRelease(release_data);
       } catch(e) {
         throw new qx.tool.cli.Utils.UserError(e.message);
+      }
+      // add GitHub topic
+      const topic = "qooxdoo-contrib";
+      if( ! topics.includes(topic) ){
+        topics.push(topic);
+        await octokit.repos.replaceTopics({owner, repo, names:topics});
+        if( ! argv.quiet ) {
+          console.info(`Added GitHub topic '${topic}'.`);
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,36 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@octokit/rest": {
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.9.4.tgz",
+      "integrity": "sha512-v3CS1qW4IjriMvGgm4lDnYFBJlkwvzIbTxiipOcwVP8xeK8ih2pJofRhk7enmLngTtNEa+sIApJNkXxyyDKqLg==",
+      "requires": {
+        "before-after-hook": "^1.1.0",
+        "btoa-lite": "^1.0.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.0",
+        "lodash": "^4.17.4",
+        "node-fetch": "^2.1.1",
+        "url-template": "^2.0.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "node-fetch": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+        }
+      }
+    },
     "@qooxdoo/preset-env": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@qooxdoo/preset-env/-/preset-env-1.0.0.tgz",
@@ -83,6 +113,29 @@
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+        }
+      }
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+        },
+        "es6-promisify": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+          "requires": {
+            "es6-promise": "^4.0.3"
+          }
         }
       }
     },
@@ -953,6 +1006,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -1085,6 +1143,11 @@
         "caniuse-lite": "^1.0.30000792",
         "electron-to-chromium": "^1.3.30"
       }
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer": {
       "version": "3.6.0",
@@ -3484,6 +3547,25 @@
         "statuses": ">= 1.4.0 < 2"
       }
     },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -3492,6 +3574,25 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "iconv-lite": {
@@ -6237,6 +6338,11 @@
       "requires": {
         "prepend-http": "^1.0.1"
       }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "url-to-options": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@octokit/rest": "^15.9.4",
     "@qooxdoo/preset-env": "^1.0.0",
     "app-module-path": "^2.2.0",
     "async": "^2.4.1",


### PR DESCRIPTION
`qx contrib publish` uses the better maintained [OctoKit](https://www.npmjs.com/package/@octokit/rest) library instead of `github-api` now, I will switch the other commands to the newer library as time permits. 