### PR TITLE
Source Maps: set sourceFileName explicitly

### DIFF
--- a/lib/qx/tool/compiler/ClassFile.js
+++ b/lib/qx/tool/compiler/ClassFile.js
@@ -278,6 +278,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
         try {
           var result = babelCore.transform(src, {
             babelrc: false,
+            sourceFileName : t.getSourcePath(),
             filename: t.getSourcePath(),
             sourceMaps: true,
             presets: [ "@qooxdoo/preset-env" ].map(require.resolve),


### PR DESCRIPTION
Set sourceFileName in babel's transform options explicitly when generating source maps. The full file path allows to distinguish between transpiled and source file even if they have the same name.

This allows chrome dev tools workspaces to save changes back to disk.
https://babeljs.io/docs/en/6.26.3/babel-core#options