### PR TITLE
Some minor changes

### DIFF
--- a/lib/qx/tool/cli/commands/Command.js
+++ b/lib/qx/tool/cli/commands/Command.js
@@ -174,7 +174,10 @@ qx.Class.define("qx.tool.cli.commands.Command", {
           };
         }
       }
-      
+      return this.getGlobalQxPath();
+    },
+    
+    getGlobalQxPath: async function() {
       // Config override
       let cfg = await qx.tool.cli.ConfigDb.getInstance();
       let dir = cfg.db("qx.library");
@@ -194,7 +197,6 @@ qx.Class.define("qx.tool.cli.commands.Command", {
       let filename = require.resolve("qooxdoo-sdk/package.json");
       return path.join(path.dirname(filename), "framework");
     },
-
 
     /**
      * Returns the absolute path to the qooxdoo framework used by the current project, unless
@@ -304,6 +306,7 @@ qx.Class.define("qx.tool.cli.commands.Command", {
     /**
      * Returns the absolute path to the node_module directory
      * @return {String}
+     * not used
      */
     getNodeModuleDir : function(){
       return  path.join( __dirname, "../../../../../node_modules");

--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -359,13 +359,6 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       if (t.argv["app-name"])
         appNames = t.argv["app-name"].split(',');
       
-      // if only one app set writeIndexHtmlToRoot = true
-      if (data.applications.length === 1) {
-        let appData = data.applications[0];
-        if (appData["default"] === undefined) {
-          appData["default"] = true;
-        }
-      }
       let hasExplicitDefaultApp = false;
       let defaultApp = null;
       data.applications.forEach(function(appData, appIndex) {

--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -362,8 +362,8 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       // if only one app set writeIndexHtmlToRoot = true
       if (data.applications.length === 1) {
         let appData = data.applications[0];
-        if (appData.writeIndexHtmlToRoot === undefined) {
-          appData.writeIndexHtmlToRoot = true;
+        if (appData["default"] === undefined) {
+          appData["default"] = true;
         }
       }
       let hasExplicitDefaultApp = false;
@@ -464,25 +464,12 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       // Search for Qooxdoo library if not already provided
       var qxLib = maker.getAnalyser().findLibrary("qx");
       if (!qxLib) {
-        // Config override
-        let cfg = await qx.tool.cli.ConfigDb.getInstance();
-        let dir = cfg.db("qx.library");
-        if (dir && await fs.existsAsync(path.join(dir, "Manifest.json"))) {
-          await maker.addLibrary(dir);
-          return maker;
-        }
-        
-        // This project's node_modules
-        if (await fs.existsAsync("node_modules/qooxdoo-sdk/framework/Manifest.json")) {
-          await maker.addLibrary("node_modules/qooxdoo-sdk/framework");
-          return maker;
-        }
-        
-        // The compiler's qooxdoo
-        let filename = require.resolve("qooxdoo-sdk/package.json");
-        await maker.addLibrary(path.join(path.dirname(filename), "framework"));
+        await addLibraryAsync(await this.getGlobalQxPath());
       }
-      
+      if (this.argv.verbose) {
+        var qxLib = maker.getAnalyser().findLibrary("qx");
+        console.log("QooxDoo found in " + qxLib.getRootDir());
+      }
       return maker;
     },
 

--- a/tool/cli/templates/skeleton/desktop/compile.tmpl.json
+++ b/tool/cli/templates/skeleton/desktop/compile.tmpl.json
@@ -22,8 +22,7 @@
     {
       "class": "${namespace}.Application",
       "theme": "${namespace}.theme.Theme",
-      "name": "${namespace}",
-      "writeIndexHtmlToRoot": true
+      "name": "${namespace}"
     }
   ]
 }

--- a/tool/cli/templates/skeleton/mobile/compile.tmpl.json
+++ b/tool/cli/templates/skeleton/mobile/compile.tmpl.json
@@ -21,8 +21,7 @@
   "applications": [
     {
       "class": "${namespace}.Application",
-      "name": "${namespace}",
-      "writeIndexHtmlToRoot": true
+      "name": "${namespace}"
     }
   ]
 }


### PR DESCRIPTION
   - remove writeIndexHtmlToRoot from template
   - fix writeIndexHtmlToRoot if only one application is configured
   - DRY: move search of qooxdoo to getGlobalQxPath in Command.js
   - if --verbose log qooxdoo path