### PR TITLE
Fix app root 2: work for blank projects too.

### DIFF
--- a/lib/qx/tool/cli/commands/Serve.js
+++ b/lib/qx/tool/cli/commands/Serve.js
@@ -161,8 +161,8 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
               return { 
                 name: app.getName(),
                 type: app.getType(),
-                title: app.getTitle(),
-                outputPath: app.getOutputPath() + "/"
+                title: app.getTitle() || app.getName(),
+                outputPath: target.getProjectDir(app) + "/"
               };
             })
         };

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -874,8 +874,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
           "  </script>\n" +
           "  <script type=\"text/javascript\" src=\"" + appRoot + t.getScriptPrefix() + "boot.js\"></script>\n";
 
-        function writeDefaultIndexHtml() {
-          let s =
+        let defaultIndexHtml =
             "<!DOCTYPE html>\n" +
             "<html>\n" +
             "<head>\n" +
@@ -886,11 +885,8 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
             "  <!-- This index.html can be customised by creating a boot/index.html (do not include Qooxdoo application script tags like\n" +
             "       the one below because they will be added automatically)\n" +
             "    -->\n" +
-            bootJs +
             "</body>\n" +
             "</html>\n";        
-          return writeFile(appRootDir + t.getScriptPrefix() + "index.html", s, { encoding: "utf8" });
-        }
         
         var classname = application.getClassName();
         var library = t.getAnalyser().getLibraryFromClassname(classname);
@@ -903,19 +899,21 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
         }catch(ex) {
           stats = null;
         }
+        let html;
         if (!stats || !stats.isDirectory()) {
-          return writeDefaultIndexHtml();
-        }
-        await qx.tool.compiler.files.Utils.sync(bootDir, resDir, (from, to) => !from.endsWith("index.html"));
-        var stats = await stat(path.join(bootDir, "index.html"));
-        if (stats.isFile()) {
-          let html = await readFile(path.join(bootDir, "index.html"), { encoding: "utf8" });
-          let str = bootJs + "</body>";
-          let after = html.replace(/\<\/body\>/, str);
-          return writeFile(appRootDir + t.getScriptPrefix() + "index.html", after, { encoding: "utf8" });
+          html = defaultIndexHtml;
         } else {
-          return writeDefaultIndexHtml() ;
+          await qx.tool.compiler.files.Utils.sync(bootDir, resDir, (from, to) => !from.endsWith("index.html"));
+          var stats = await stat(path.join(bootDir, "index.html"));
+          if (stats.isFile()) {
+            html = await readFile(path.join(bootDir, "index.html"), { encoding: "utf8" });
+          } else {
+            html = defaultIndexHtml;
+          }  
         }
+        let str = bootJs + "</body>";
+        let after = html.replace("</body>", str);
+        return writeFile(appRootDir + t.getScriptPrefix() + "index.html", after, { encoding: "utf8" });
       };
       
       if (application.getWriteIndexHtmlToRoot()) {


### PR DESCRIPTION
The first fix only works for projects with included boot/index.html not for blank projects.
This patch also fix the output path for serve.