### PR TITLE
fix relative paths in serve

### DIFF
--- a/lib/qx/tool/cli/commands/Serve.js
+++ b/lib/qx/tool/cli/commands/Serve.js
@@ -20,7 +20,6 @@ require("qooxdoo");
 const fs = qx.tool.compiler.utils.Promisify.fs;
 const path = require('upath');
 const process = require('process');
-const http = require('http');
 const express = require('express');
 
 require('app-module-path').addPath(process.cwd() + '/node_modules');
@@ -151,11 +150,11 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
         app.use('/', express.static(target.getOutputDir()));
       } else {
         app.use('/', express.static(path.join(__dirname, "../../../../../tool/cli/serve/build")))
-        app.use('/' + target.getOutputDir(), express.static(target.getOutputDir()));
+        app.use('/build/', express.static(target.getOutputDir()));
         var obj = {
             target: {
               type: target.getType(),
-              outputDir: target.getOutputDir()
+              outputDir: '/build/'
             },
             apps: apps.map(app => { 
               return { 
@@ -175,13 +174,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
         }
         getJson("/serve.api/apps.json", obj);
       }
-
-      const webServer = http.createServer(app);
-      return new Promise((resolve, reject) => {
-        webServer.listen(config.serve.listenPort, function(err) {
-          qx.tool.compiler.Console.print("qx.tool.cli.serve.webStarted", "http://localhost:" + config.serve.listenPort)
-        });
-      });
+      app.listen(config.serve.listenPort, () => qx.tool.compiler.Console.print("qx.tool.cli.serve.webStarted", "http://localhost:" + config.serve.listenPort));
     },
     
     /*


### PR DESCRIPTION
if you have relative paths in target.getOutputDir() app.use will not work.
Therefore use fix path to service apps