### PR TITLE
fixes for contib install and remove

### DIFF
--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -131,7 +131,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
         };
         if( index >= 0 ){
           data.libraries[index]=library_elem;
-          if (! argv.quiet) console.info(`Updating already existing config.json.json entry '${info.name}'.`);
+          if (! argv.quiet) console.info(`Updating already existing config.json entry '${info.name}'.`);
         } else {
           data.libraries.push(library_elem);
         }
@@ -165,6 +165,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       });
       if (!app) {
         compileJson.applications.push(manifestApp);
+        app = manifestApp;
       } else {
         for (let key in manifestApp)
           app[key] = manifestApp[key];

--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -152,7 +152,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       let manifest = await qx.tool.compiler.utils.Json.loadJsonAsync(path.join(libraryJson.path, "Manifest.json"), "utf8");
       if (!manifest.provides || !manifest.provides.application) {
         if (this.argv.verbose) 
-          console.info(">>> No applications to install.");
+          console.info(">>> No application to install.");
         return;
       }
       

--- a/lib/qx/tool/cli/commands/contrib/Publish.js
+++ b/lib/qx/tool/cli/commands/contrib/Publish.js
@@ -143,7 +143,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
       }
       let token = github.token;
       if( ! token ){
-        throw new qx.tool.cli.Utils.UserError(`GitHub access token required. Pass it via --token or set the environment variable ${ENV_GH_ACCESS_TOKEN}`);
+        throw new qx.tool.cli.Utils.UserError(`GitHub access token required.`);
       }
       octokit.authenticate({
         type: 'token',
@@ -262,7 +262,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
           name: "message",
           message: `Please enter a commit message:`
         };
-        let answer = await inquirer.prompt(question);
+        let answer = await inquirer.prompt([question]);
         message = answer.message;
       } 
       if( ! message ) {

--- a/lib/qx/tool/cli/commands/contrib/Remove.js
+++ b/lib/qx/tool/cli/commands/contrib/Remove.js
@@ -24,8 +24,8 @@ require("qooxdoo");
 const fs = require('fs');
 const path_module = require('upath');
 const process = require('process');
+const path = require('upath');
 const rimraf = require('rimraf');
-const jsonlint = require("jsonlint");
 
 /**
  * Installs a contrib libraries
@@ -73,6 +73,8 @@ qx.Class.define("qx.tool.cli.commands.contrib.Remove", {
         throw new qx.tool.cli.Utils.UserError( "No repository name given.");
       }
       
+      await this.removeApplication(repo_name);
+
       // read libraries array from contrib.json
       let data = await this.getContribData();
     
@@ -94,6 +96,37 @@ qx.Class.define("qx.tool.cli.commands.contrib.Remove", {
       }
       data.libraries = libraries;
       fs.writeFileSync( this.getContribFileName(), JSON.stringify(data, null, 2), "utf-8");
+    },
+    removeApplication: async function(repoName) {
+      let contribJson = await this.getContribData();
+      let libraryJson = contribJson.libraries.find(data => data.repo_name == repoName);
+      if (!libraryJson)
+        throw new Error("Repo for " + repoName + " is not installed as a contrib");
+      
+      let manifest = await qx.tool.compiler.utils.Json.loadJsonAsync(path.join(libraryJson.path, "Manifest.json"), "utf8");
+      if (!manifest.provides || !manifest.provides.application) {
+        if (this.argv.verbose) 
+          console.info(">>> No application to remove.");
+        return;
+      }
+
+      let compileJson = await qx.tool.compiler.utils.Json.loadJsonAsync("compile.json");
+      let manifestApp = manifest.provides.application;
+      let app = compileJson.applications.find(app => {
+        if (manifestApp.name && app.name)
+          return manifestApp.name == app.name;
+        return manifestApp["class"] == app["class"];
+      });
+      if (app) {
+        let idx = compileJson.applications.indexOf(app);
+        compileJson.applications.splice(idx, 1);
+
+        if (this.argv.verbose) 
+          console.info(">>> Removed application " + (app.name||app["class"]));
+        return await qx.tool.compiler.utils.Json.saveJsonAsync("compile.json", compileJson);
+
+
+      }  
     }
   }
 });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1863,8 +1863,15 @@
     },
     "es6-promise": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
       "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
+    },
+    "es6-promisify": {
+      "version": "github:pgaubatz/es6-promisify#3d8966c58bace65f762b7335e99e3f43b987bce4",
+      "from": "github:pgaubatz/es6-promisify",
+      "requires": {
+        "es6-promise": "^2.3.0"
+      }
     },
     "es6-promisify-all": {
       "version": "0.1.0",
@@ -1872,15 +1879,6 @@
       "integrity": "sha1-RCuaHqjgCw/VsodyVVBY/eXp8gc=",
       "requires": {
         "es6-promisify": "github:pgaubatz/es6-promisify#3d8966c58bace65f762b7335e99e3f43b987bce4"
-      },
-      "dependencies": {
-        "es6-promisify": {
-          "version": "github:pgaubatz/es6-promisify#3d8966c58bace65f762b7335e99e3f43b987bce4",
-          "from": "github:pgaubatz/es6-promisify",
-          "requires": {
-            "es6-promise": "^2.3.0"
-          }
-        }
       }
     },
     "es6-set": {
@@ -3698,21 +3696,20 @@
       }
     },
     "inquirer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.2.tgz",
-      "integrity": "sha512-+f3qDNeZpkhFJ61NBA9jXDrGGhoQuqfEum9A681c9oHoIbGgVqjogKynjB/vNVP+nVu9w3FbFQ35c0ibU0MaIQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
       "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
+        "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "lodash": "^4.17.10",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
+        "rxjs": "^6.1.0",
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
@@ -3741,6 +3738,29 @@
             "supports-color": "^5.3.0"
           }
         },
+        "chardet": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+          "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+        },
+        "external-editor": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+          "requires": {
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -3750,9 +3770,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -5462,6 +5482,14 @@
         "rx-lite": "*"
       }
     },
+    "rxjs": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -6117,6 +6145,11 @@
       "requires": {
         "glob": "^7.1.2"
       }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "node.js based replacement for the Qooxdoo python toolchain",
   "main": "index.js",
   "scripts": {
-    "test": "cross-os test.os"
+    "test": "cross-os test.os",
+    "compileWebSite": "cd tool/cli/serve && node compile.js"
   },
   "cross-os": {
     "test.os": {
@@ -58,7 +59,7 @@
     "github-api": "^3.0.0",
     "glob": "^7.1.3",
     "image-size": "^0.6.3",
-    "inquirer": "^4.0.0",
+    "inquirer": "^6.2.0",
     "json-to-ast": "git+https://github.com/johnspackman/json-to-ast.git#editable-json",
     "jsonlint": "^1.6.2",
     "node-fetch": "^1.7.3",


### PR DESCRIPTION
- update inquirer to version 6.2. The older one did not work in windows 
- add a npm job to create the website
- fix remove command so that the application of the contrib will be removed from compile.json. Opposite of install, there the appliccation of the contrib is added to compile.json
- fix some typos

