### PR TITLE
fixes inner classes and ES6 functions

### DIFF
--- a/lib/qx/tool/compiler/Analyser.js
+++ b/lib/qx/tool/compiler/Analyser.js
@@ -744,7 +744,7 @@ module.exports = qx.Class.define("qx.tool.compiler.Analyser", {
       async function analyzeMeta() {
         var toSave = {};
         for (var classname in compiledClasses) {
-          var meta = cachedMeta[classname] = compiledClasses[classname].classFile.getMeta();
+          var meta = cachedMeta[classname] = compiledClasses[classname].classFile.getOuterClassMeta();
           fixupMetaData(classname, meta);
         }
         

--- a/lib/qx/tool/compiler/ClassFile.js
+++ b/lib/qx/tool/compiler/ClassFile.js
@@ -165,6 +165,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
     
     this.__analyser = analyser;
     this.__className = className;
+    this.__metaStack = [];
+    this.__metaDefinitions = {};
     this.__library = library;
     this.__sourceFilename = qx.tool.compiler.ClassFile.getSourcePath(library, className);
 
@@ -198,6 +200,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
 
     __analyser: null,
     __className: null,
+    __numClassesDefined: 0,
     __library: null,
     __requiredClasses: null,
     __environmentChecks: null,
@@ -208,10 +211,11 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
     __inConstruct: false,
     __taskQueue: null,
     __taskQueueDrains: null,
-    __functionName: null,
     __markers: null,
     __haveMarkersFor: null,
-    __meta: null,
+    __classMeta: null,
+    __metaStack: null,
+    __metaDefinitions: null,
     __fatalCompileError: false,
 
     _onTaskQueueDrain: function() {
@@ -248,7 +252,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
     getOutputPath: function() {
       return qx.tool.compiler.ClassFile.getOutputPath(this.__analyser, this.__className);
     },
-
+    
     /**
      * Loads the source, transpiles and analyses the code, storing the result in outputPath
      *
@@ -258,22 +262,13 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
     load: function (callback) {
       var t = this;
       var analyser = this.__analyser;
+      var className = this.__className;
       t.__fatalCompileError = false;
-      t.__foundClassDef = false;
+      t.__numClassesDefined = 0;
 
       fs.readFile(this.getSourcePath(), {encoding: "utf-8"}, function (err, src) {
         if (err)
           return callback(err);
-
-        var pos = t.__className.lastIndexOf('.'); 
-        t.__meta = {
-            className: t.__className,
-            packageName: pos > -1 ? t.__className.substring(0, pos) : null,
-            name: pos > -1 ? t.__className.substring(pos + 1) : t.__className,
-            superClass: null,
-            interfaces: [],
-            mixins: []
-        };
 
         try {
           var result = babelCore.transform(src, {
@@ -294,18 +289,23 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
           return callback();
         }
         
-        if (!t.__foundClassDef) {
+        if (!t.__numClassesDefined) {
           t.addMarker("compiler.missingClassDef");
           t.__fatalCompileError = true;
           t._compileDbClassInfo();
           return callback();
         }
 
+        if (!t.__metaDefinitions[className])
+          t.addMarker("compiler.wrongClassName");
+
+        var pos = className.lastIndexOf('.'); 
+        var name = pos > -1 ? className.substring(pos + 1) : className;
         var outputPath = t.getOutputPath();
         util.mkParentPath(outputPath, function(err) {
           if (err)
             return callback(err);
-          fs.writeFile(outputPath, result.code + "\n\n//# sourceMappingURL=" + t.__meta.name + ".js.map?dt=" + (new Date().getTime()), {encoding: "utf-8"}, function(err) {
+          fs.writeFile(outputPath, result.code + "\n\n//# sourceMappingURL=" + name + ".js.map?dt=" + (new Date().getTime()), {encoding: "utf-8"}, function(err) {
             if (err)
               return callback(err);
             fs.writeFile(outputPath + ".map", JSON.stringify(result.map, null, 2), {encoding: "utf-8"}, function(err) {
@@ -370,7 +370,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
         });
       }
       
-      var meta = this.__meta;
+      var meta = this.getOuterClassMeta();
       fixAnnos(meta.events);
       fixAnnos(meta.members);
       fixAnnos(meta.statics);
@@ -459,8 +459,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
     /**
      * Returns the loaded meta data
      */
-    getMeta: function() {
-      return this.__meta;
+    getOuterClassMeta: function() {
+      return this.__metaDefinitions[this.__className];
     },
     
     /**
@@ -473,21 +473,24 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
         var keyName = key.type == "StringLiteral" ? key.value : key.name;
         return keyName;
       }
+      
+      function enterFunction(path) {
+        var node = path.node;
+        if (node.id)
+          t.addDeclaration(node.id.name);
+        t.pushScope(node.id ? node.id.name : null, node);
+        for (var i = 0; i < node.params.length; i++)
+          t.addDeclaration(node.params[i].name);
+      }
+      
+      function exitFunction(path) {
+        var node = path.node;
+        t.popScope(node);
+      }
 
-      var functionDeclOrExpr = {
-        enter(path) {
-          var node = path.node;
-          if (node.id)
-            t.addDeclaration(node.id.name);
-          t.pushScope(node.id ? node.id.name : null, node);
-          for (var i = 0; i < node.params.length; i++)
-            t.addDeclaration(node.params[i].name);
-        },
-
-        exit(path) {
-          var node = path.node;
-          t.popScope(node);
-        }
+      var FUNCTION_DECL_OR_EXPR = {
+        enter: enterFunction,
+        exit: exitFunction
       };
 
       function getClassNames(node) {
@@ -529,16 +532,16 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
           debugger;
         var meta;
         if (functionName) {
-          var section = t.__meta[sectionName];
+          var section = t.__classMeta[sectionName];
           if (section === undefined)
-            section = t.__meta[sectionName] = {};
+            section = t.__classMeta[sectionName] = {};
           meta = section[functionName];
           if (meta === undefined)
             meta = section[functionName] = {};
         } else {
-          meta = t.__meta[sectionName];
+          meta = t.__classMeta[sectionName];
           if (meta === undefined)
-            meta = t.__meta[sectionName] = {};
+            meta = t.__classMeta[sectionName] = {};
         }
         meta.location = node.loc;
         
@@ -555,7 +558,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
         }
         
         if (sectionName === "members" || sectionName === "statics") {
-          if (node.value.type === "FunctionExpression")
+          if (node.type == "ObjectMethod" || node.value.type === "FunctionExpression")
             meta.type = "function";
           else
             meta.type = "variable";
@@ -718,22 +721,22 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
           var keyName = getKeyName(prop.key);
 
           if (keyName == "extend") {
-            t.__meta.superClass = collapseMemberExpression(prop.value);
-            t._requireClass(t.__meta.superClass, { location: path.node.loc });
+            t.__classMeta.superClass = collapseMemberExpression(prop.value);
+            t._requireClass(t.__classMeta.superClass, { location: path.node.loc });
 
           } else if (keyName == "type") {
             var type = collapseMemberExpression(prop.value);
-            t.__meta.isAbstract = type === "abstract";
-            t.__meta.isStatic = type === "static";
-            t.__meta.isSingleton = type === "singleton";
+            t.__classMeta.isAbstract = type === "abstract";
+            t.__classMeta.isStatic = type === "static";
+            t.__classMeta.isSingleton = type === "singleton";
 
           } else if (keyName == "implement") {
             path.skip();
-            path.traverse(COLLECT_CLASS_NAMES_VISITOR, { collectedClasses: t.__meta.interfaces });
+            path.traverse(COLLECT_CLASS_NAMES_VISITOR, { collectedClasses: t.__classMeta.interfaces });
 
           } else if (keyName == "include") {
             path.skip();
-            path.traverse(COLLECT_CLASS_NAMES_VISITOR, { collectedClasses: t.__meta.mixins });
+            path.traverse(COLLECT_CLASS_NAMES_VISITOR, { collectedClasses: t.__classMeta.mixins });
 
           } else if (keyName == "defer") {
             t.__hasDefer = true;
@@ -744,18 +747,18 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             t.__inDefer = false;
 
           } else if (keyName == "construct") {
-            t.__functionName = "$$constructor";
+            t.__classMeta.functionName = "$$constructor";
             makeMeta("construct", null, path.node);
             path.skip();
             path.traverse(VISITOR);
-            t.__functionName = null;
+            t.__classMeta.functionName = null;
 
           } else if (keyName == "destruct") {
-            t.__functionName = "$$destructor";
+            t.__classMeta.functionName = "$$destructor";
             makeMeta("destruct", null, path.node);
             path.skip();
             path.traverse(VISITOR);
-            t.__functionName = null;
+            t.__classMeta.functionName = null;
 
           } else if (keyName == "statics") {
             if (this.__className == "qx.core.Environment") {
@@ -773,18 +776,14 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                 if (path.parentPath.parentPath != staticsPath) {
                   return path.traverse(VISITOR);
                 }
-                t.__functionName = getKeyName(path.node.key);
-                var meta = makeMeta("statics", t.__functionName, path.node);
-                if (path.node.value.type === "FunctionExpression")
-                  meta.type = "function";
-                else
-                  meta.type = "variable";
+                t.__classMeta.functionName = getKeyName(path.node.key);
+                var meta = makeMeta("statics", t.__classMeta.functionName, path.node);
                 path.traverse(VISITOR);
-                t.__functionName = null;
+                t.__classMeta.functionName = null;
               },
-              FunctionDeclaration: functionDeclOrExpr,
-              FunctionExpression: functionDeclOrExpr,
-              ArrowFunctionExpression: functionDeclOrExpr
+              FunctionDeclaration: FUNCTION_DECL_OR_EXPR,
+              FunctionExpression: FUNCTION_DECL_OR_EXPR,
+              ArrowFunctionExpression: FUNCTION_DECL_OR_EXPR
             });
 
           } else if (keyName == "members") {
@@ -796,14 +795,26 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                 if (path.parentPath.parentPath != membersPath) {
                   return path.traverse(VISITOR);
                 }
-                t.__functionName = getKeyName(path.node.key);
-                var meta = makeMeta("members", t.__functionName, path.node);
+                t.__classMeta.functionName = getKeyName(path.node.key);
+                var meta = makeMeta("members", t.__classMeta.functionName, path.node);
                 path.traverse(VISITOR);
-                t.__functionName = null;
+                t.__classMeta.functionName = null;
               },
-              FunctionDeclaration: functionDeclOrExpr,
-              FunctionExpression: functionDeclOrExpr,
-              ArrowFunctionExpression: functionDeclOrExpr
+              ObjectMethod(path) {
+                path.skip();
+                if (path.parentPath.parentPath != membersPath) {
+                  return path.traverse(VISITOR);
+                }
+                t.__classMeta.functionName = getKeyName(path.node.key);
+                var meta = makeMeta("members", t.__classMeta.functionName, path.node);
+                enterFunction(path);
+                path.traverse(VISITOR);
+                exitFunction(path);
+                t.__classMeta.functionName = null;
+              },
+              FunctionDeclaration: FUNCTION_DECL_OR_EXPR,
+              FunctionExpression: FUNCTION_DECL_OR_EXPR,
+              ArrowFunctionExpression: FUNCTION_DECL_OR_EXPR
             });
             
           } else if (keyName == "properties") {
@@ -881,6 +892,14 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
         }
       };
 
+      const TYPE = {
+          "qx.Class.define": "class",
+          "qx.Mixin.define": "mixin",
+          "qx.Theme.define": "theme",
+          "qx.Interface.define": "interface",
+          "qx.Bootstrap.define": "class"
+      };
+      
       var VISITOR = {
         NewExpression: {
           enter(path) {
@@ -931,14 +950,6 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             if (types.isMemberExpression(path.node.callee)) {
               var name = collapseMemberExpression(path.node.callee);
 
-              const TYPE = {
-                  "qx.Class.define": "class",
-                  "qx.Mixin.define": "mixin",
-                  "qx.Theme.define": "theme",
-                  "qx.Interface.define": "interface",
-                  "qx.Bootstrap.define": "class"
-              };
-              
               if (TYPE[name]) {
                 t.__definingType = name.match(/\.([a-zA-Z]+)\./)[1];
                 var node = path.node;
@@ -950,14 +961,11 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                   return;
                 }
                 
-                // Only process the class for the file (everything else is private/nested/anonymous)
-                if (className != t.__className) {
-                  return;
-                }
-                t.__foundClassDef = true;
+                // Create new meta
+                t.__pushMeta(className);
   
                 var meta = makeMeta("clazz", null, path.parent);
-                t.__meta.type = TYPE[name];
+                t.__classMeta.type = TYPE[name];
                 var jsdoc = meta.jsdoc;
                 if (jsdoc) {
                   if (jsdoc["@use"]) {
@@ -990,6 +998,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                 t._requireClass(name, { usage: "dynamic", location: path.node.loc });
                 path.skip();
                 path.traverse(CLASS_DEF_VISITOR, {classDefPath: path});
+                t.__popMeta(className);
                 
                 // Must be a conventional define 
                 if (path.node.arguments.length != 2 || 
@@ -998,51 +1007,54 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                   return;
                 }
                 
-                var dbClassInfo = t._compileDbClassInfo();
-                var copyInfo = {};
-                var hasLoadDeps = false;
-                if (dbClassInfo.dependsOn) {
-                  copyInfo.dependsOn = {};
-                  Object.keys(dbClassInfo.dependsOn).forEach(key => {
-                    var tmp = copyInfo.dependsOn[key] = Object.assign({}, dbClassInfo.dependsOn[key]);
-                    if (tmp.load) {
-                      delete tmp.load;
-                      tmp.require = true;
-                      hasLoadDeps = true;
-                    }
-                  });
-                }
-                if (dbClassInfo.environment) {
-                  copyInfo.environment = dbClassInfo.environment;
-                  let required = dbClassInfo.environment.required;
-                  if (required) {
-                    for (let key in required) {
-                      if (required[key].load) {
+                // If it's the main class
+                if (className == t.__className) {
+                  var dbClassInfo = t._compileDbClassInfo();
+                  var copyInfo = {};
+                  var hasLoadDeps = false;
+                  if (dbClassInfo.dependsOn) {
+                    copyInfo.dependsOn = {};
+                    Object.keys(dbClassInfo.dependsOn).forEach(key => {
+                      var tmp = copyInfo.dependsOn[key] = Object.assign({}, dbClassInfo.dependsOn[key]);
+                      if (tmp.load) {
+                        delete tmp.load;
+                        tmp.require = true;
                         hasLoadDeps = true;
-                        break;
+                      }
+                    });
+                  }
+                  if (dbClassInfo.environment) {
+                    copyInfo.environment = dbClassInfo.environment;
+                    let required = dbClassInfo.environment.required;
+                    if (required) {
+                      for (let key in required) {
+                        if (required[key].load) {
+                          hasLoadDeps = true;
+                          break;
+                        }
                       }
                     }
                   }
-                }
-                var tmp = types.variableDeclaration("var", [ types.variableDeclarator(types.identifier("$$dbClassInfo"), literalValueToExpression(copyInfo)) ]);
-                var inject = [tmp];
-                if (hasLoadDeps) {
-                  tmp = babylon.parse("qx.Bootstrap.executePendingDefers($$dbClassInfo);").program.body;
+                  var tmp = types.variableDeclaration("var", [ types.variableDeclarator(types.identifier("$$dbClassInfo"), literalValueToExpression(copyInfo)) ]);
+                  var inject = [tmp];
+                  if (hasLoadDeps) {
+                    tmp = babylon.parse("qx.Bootstrap.executePendingDefers($$dbClassInfo);").program.body;
+                    inject.push(tmp[0]);
+                  }
+                  inject.push(types.expressionStatement(path.node));
+                  tmp = babylon.parse(t.__className + ".$$dbClassInfo = $$dbClassInfo;").program.body;
                   inject.push(tmp[0]);
+                  var block = types.blockStatement(inject);
+                  
+                  var index = -1;
+                  for (var i = 0; index === -1 && i < path.parentPath.container.length; i++) {
+                    if (path.parentPath.container[i].expression === path.node)
+                      index = i;
+                  }
+                  // If you can't find index it's because it is not a real class definition (eg unit tests or other mockups)
+                  if (index > -1)
+                    path.parentPath.container[index] = types.expressionStatement(types.callExpression(types.functionExpression(null, [], block), []));
                 }
-                inject.push(types.expressionStatement(path.node));
-                tmp = babylon.parse(t.__className + ".$$dbClassInfo = $$dbClassInfo;").program.body;
-                inject.push(tmp[0]);
-                var block = types.blockStatement(inject);
-                
-                var index = -1;
-                for (var i = 0; index === -1 && i < path.parentPath.container.length; i++) {
-                  if (path.parentPath.container[i].expression === path.node)
-                    index = i;
-                }
-                // If you can't find index it's because it is not a real class definition (eg unit tests or other mockups)
-                if (index > -1)
-                  path.parentPath.container[index] = types.expressionStatement(types.callExpression(types.functionExpression(null, [], block), []));
   
               } else if (name == "qx.core.Environment.add") {
                 var arg = path.node.arguments[0];
@@ -1088,13 +1100,13 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                 //  OK in methods - but we have to refer to superclass.methodName directly.  For ordinary
                 //  classes, we need to use constructor.methodName.base.
                 if (t.__definingType == "Mixin") {
-                  expr = expandMemberExpression(t.__className + ".$$members." + t.__functionName + ".base.call");
-                  //expr = expandMemberExpression("this.constructor.superclass.prototype." + t.__functionName + ".call");
+                  expr = expandMemberExpression(t.__classMeta.className + ".$$members." + t.__classMeta.functionName + ".base.call");
+                  //expr = expandMemberExpression("this.constructor.superclass.prototype." + t.__classMeta.functionName + ".call");
                 } else {
-                  if (t.__functionName == "$$constructor")
-                    expr = expandMemberExpression(t.__meta.superClass + ".constructor.call");
+                  if (t.__classMeta.functionName == "$$constructor")
+                    expr = expandMemberExpression(t.__classMeta.superClass + ".constructor.call");
                   else
-                    expr = expandMemberExpression(t.__className + ".prototype." + t.__functionName + ".base.call");
+                    expr = expandMemberExpression(t.__classMeta.className + ".prototype." + t.__classMeta.functionName + ".base.call");
                 }
                 path.node.arguments[0] = types.thisExpression();
                 var callExpr = types.callExpression(expr, path.node.arguments);
@@ -1105,12 +1117,12 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
 
                 var expr;
                 if (t.__definingType == "Mixin") {
-                  expr = expandMemberExpression("this.constructor.superclass.prototype." + t.__functionName + ".call");
+                  expr = expandMemberExpression("this.constructor.superclass.prototype." + t.__classMeta.functionName + ".call");
                 } else {
-                  if (t.__functionName == "$$constructor")
-                    expr = expandMemberExpression(t.__meta.superClass + ".constructor." + methodName);
+                  if (t.__classMeta.functionName == "$$constructor")
+                    expr = expandMemberExpression(t.__classMeta.superClass + ".constructor." + methodName);
                   else
-                    expr = expandMemberExpression(t.__className + ".prototype." + t.__functionName + ".base." + methodName);
+                    expr = expandMemberExpression(t.__className + ".prototype." + t.__classMeta.functionName + ".base." + methodName);
                 }
                 
                 // Original call to this.base.apply would have included arguments in the first element of the array
@@ -1209,9 +1221,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
           }
         },
 
-        FunctionDeclaration: functionDeclOrExpr,
-        FunctionExpression: functionDeclOrExpr,
-        ArrowFunctionExpression: functionDeclOrExpr,
+        FunctionDeclaration: FUNCTION_DECL_OR_EXPR,
+        FunctionExpression: FUNCTION_DECL_OR_EXPR,
+        ArrowFunctionExpression: FUNCTION_DECL_OR_EXPR,
 
         VariableDeclaration(path) {
           var lst = path.node.declarations;
@@ -1302,6 +1314,43 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
       };
 
       return { visitor: VISITOR };
+    },
+
+    /**
+     * Pushes new meta data onto the stack - each meta represents a class being defined,
+     * we operate a stack so that we can handle inner classes
+     * 
+     * @param className {String} name of the class being defined
+     */
+    __pushMeta: function(className) {
+      var pos = className.lastIndexOf('.'); 
+      var meta = {
+          className: className,
+          packageName: pos > -1 ? className.substring(0, pos) : null,
+          name: pos > -1 ? className.substring(pos + 1) : className,
+          superClass: null,
+          interfaces: [],
+          mixins: [],
+          functionName: null
+      };
+      this.__metaStack.push(meta);
+      this.__classMeta = meta;
+      this.__metaDefinitions[className] = meta;
+      this.__numClassesDefined++;
+    },
+
+    /**
+     * Pops the current meta off the stack, optionally checking that the classname is correct
+     */
+    __popMeta: function(className) {
+      if (!this.__metaStack.length)
+        throw new Error("No __metaStack entries to pop");
+      let meta = this.__metaStack[this.__metaStack.length - 1];
+      if (className && meta.className != className)
+        throw new Error("Wrong __metaStack entries to pop, expected " + className + " found " + meta.className);
+      this.__metaStack.pop();
+      meta = this.__metaStack[this.__metaStack.length - 1] || null;
+      this.__classMeta = meta;
     },
 
     /**
@@ -1482,7 +1531,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
       var requiredOpts = {
         load: t.isLoadScope(),
         defer: t.__inDefer,
-        construct: t.__functionName == "$$constructor",
+        construct: t.__classMeta.functionName == "$$constructor",
         location: location
       };
       var dest = t.__environmentChecks.required[name];
@@ -1590,7 +1639,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
       var requireOpts = {
         load: t.isLoadScope(),
         defer: t.__inDefer,
-        construct: t.__functionName == "$$constructor"
+        construct: t.__classMeta.functionName == "$$constructor"
       };
       if (opts)
         for (var key in opts)

--- a/lib/qx/tool/compiler/Console.js
+++ b/lib/qx/tool/compiler/Console.js
@@ -98,11 +98,12 @@ qx.Class.define("qx.tool.compiler.Console", {
   defer: function(statics) {
     statics.addMessageIds({
       // Compiler errors & warnings (@see {ClassFile})
-      "qx.tool.compiler.symbol.unresolved": "Unresolved use of symbol %1",
-      "qx.tool.compiler.defer.unsafe": "Unsafe use of 'defer' method to access external class: %1",
       "qx.tool.compiler.class.invalidProperties": "Invalid 'properties' key in class definition",
-      "qx.tool.compiler.compiler.syntaxError": "Syntax error: %1\n%2",
       "qx.tool.compiler.compiler.missingClassDef": "Missing class definition - no call to qx.Class.define (or qx.Mixin.define etc)",
+      "qx.tool.compiler.compiler.syntaxError": "Syntax error: %1\n%2",
+      "qx.tool.compiler.compiler.wrongClassName": "Wrong class name or filename - the filename does not match any classes defined",
+      "qx.tool.compiler.defer.unsafe": "Unsafe use of 'defer' method to access external class: %1",
+      "qx.tool.compiler.symbol.unresolved": "Unresolved use of symbol %1",
       
       // Application errors & warnings (@see {Application})
       "qx.tool.compiler.application.partRecursive": "Part %1 has recursive dependencies on other parts",
@@ -110,6 +111,8 @@ qx.Class.define("qx.tool.compiler.Console", {
       "qx.tool.compiler.application.noBootPart": "Cannot find a boot part",
       "qx.tool.compiler.application.conflictingExactPart": "Conflicting exact match for %1, could be %2 or %3",
       "qx.tool.compiler.application.conflictingBestPart": "Conflicting best match for %1, could be %2 or %3",
+      
+      "qx.tool.compiler.library.emptyManifest": "Empty Manifest.json in library at %1",
       
       // Targets
       "qx.tool.compiler.build.uglifyParseError": "Parse error in output file %4, line %1 column %2: %3",

--- a/lib/qx/tool/compiler/app/Library.js
+++ b/lib/qx/tool/compiler/app/Library.js
@@ -141,6 +141,10 @@ qx.Class.define("qx.tool.compiler.app.Library", {
       t.setRootDir(rootDir);
       qx.tool.compiler.utils.Json.loadJsonAsync(rootDir + "/Manifest.json")
         .then(data => {
+          if (!data) {
+            var Console = qx.tool.compiler.Console.getInstance();
+            throw new Error(Console.decode("qx.tool.compiler.library.emptyManifest", rootDir));
+          }
           t.setNamespace(data.provides.namespace);
           t.setVersion(data.info.version);
           var sourcePath = data.provides["class"];

--- a/test/testapp/compile.json
+++ b/test/testapp/compile.json
@@ -48,10 +48,5 @@
         "pluginTwo": {
             "include": [ "testapp.plugins.PluginTwo" ]
         }
-	},
-	
-	"libraries": [
-		"../../qooxdoo/framework",
-		"."
-	]
+	}
 }

--- a/test/testapp/contrib.json
+++ b/test/testapp/contrib.json
@@ -2,10 +2,10 @@
   "libraries": [
     {
       "library_name": "Dialog",
-      "library_version": "1.3",
+      "library_version": "1.4.0",
       "repo_name": "cboulanger/qx-contrib-Dialog",
-      "repo_tag": "v1.3.0-beta.3",
-      "path": "contrib/cboulanger_qx-contrib-Dialog_v1.3.0-beta.3/."
+      "repo_tag": "v1.4.0",
+      "path": "contrib/cboulanger_qx-contrib-Dialog_v1.4.0"
     }
   ]
 }

--- a/test/testapp/source/class/testapp/Application.js
+++ b/test/testapp/source/class/testapp/Application.js
@@ -136,6 +136,8 @@ qx.Class.define("testapp.Application", {
         var plugin = new testapp.plugins.PluginTwo();
         console.log(plugin.sayHello());
       }, this);
+      
+      new testapp.test.TestInnerClasses().testInnerClasses();
     },
 
     undocumentedMethod: function () {

--- a/test/testapp/source/class/testapp/test/TestInnerClasses.js
+++ b/test/testapp/source/class/testapp/test/TestInnerClasses.js
@@ -1,0 +1,27 @@
+qx.Class.define("testapp.test.TestInnerClasses", {
+  extend: qx.dev.unit.TestCase,
+  
+  members: {
+    funcOne: function() {
+      return this.base(arguments);
+    },
+    funcTwo() {
+      return this.base(arguments);
+    },
+    testInnerClasses() {
+      var clazz = qx.Class.define("demo.MyClass", {
+        extend: qx.core.Object,
+        members: {
+          toHashCode: function() {
+            return this.base(arguments) + "";
+          }
+        }
+      });
+      
+      var obj = new clazz();
+      obj.toHashCode();
+      qx.core.Assert.assertTrue(true);
+      this.base(arguments);
+    }
+  }
+});

--- a/test/testapp/source/translation/en.po
+++ b/test/testapp/source/translation/en.po
@@ -1,0 +1,19 @@
+#: dialog/Dialog.js:417 dialog/Form.js:457
+msgid "OK"
+msgstr ""
+
+#: dialog/Dialog.js:443
+msgid "Cancel"
+msgstr ""
+
+#: dialog/Confirm.js:117
+msgid "yes"
+msgstr ""
+
+#: dialog/Confirm.js:129
+msgid "no"
+msgstr ""
+
+#: dialog/Form.js:396
+msgid "Value is invalid"
+msgstr ""


### PR DESCRIPTION
This fixes a bug where nested or inner classes (ie calling `qx.Class.define` inside a method inside another call to `qx.Class.define`) was broken, something which is typically used in unit tests.

Also this fixes the ES6 form of functions eg you can now write this code:

```
qx.Class.define("mypackage.MyClass", {
  members: {
    doSomething() {
        this.doSomethingMore(“hello");
    },

    doSomethingMore(value) {
        console.log("value=" + value);
    }
  }
});
```