### PR TITLE
Cboulanger add implicit update to install

### DIFF
--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -77,17 +77,24 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       let argv = this.argv;
       let repos_cache = this.getCache().repos;
 
-      if ( repos_cache.list.length == 0 ){
-        throw new qx.tool.cli.Utils.UserError("You need to execute 'qx contrib update' first.");
+      if ( repos_cache.list.length === 0 ){
+        if (!this.argv.quiet) {
+          console.info("Updating cache...");
+        }
+        this.clearCache();
+        // implicit update
+        await (new qx.tool.cli.commands.contrib.Update({quiet:true})).process();
+        await (new qx.tool.cli.commands.contrib.List({quiet:true})).process();
+        repos_cache = this.getCache().repos;
       }
 
       if (!argv.repository) {
-        this.__loadFromContrib();
+        this.__loadFromContribJson();
         return;
       }
    
       let qooxdoo_version = await this.getUserQxVersion();
-      if(argv.verbose) console.log(`>>> qooxdoo version:  ${qooxdoo_version}`);
+      if(argv.verbose) console.info(`>>> qooxdoo version:  ${qooxdoo_version}`);
      
       // has a repository name been given?
       if (!argv.repository) {
@@ -119,8 +126,8 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       for( let { info, path:filename } of release_data.manifests ) {
         // does the repository name already exist?
         let index = data.libraries.findIndex((elem)=>{
-          return elem.repo_name == repo_name 
-            && elem.library_name == info.name;
+          return elem.repo_name === repo_name
+            && elem.library_name === info.name;
         });
         library_elem = {
           library_name : info.name,
@@ -138,14 +145,12 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       }
       await fs.writeFileAsync(this.getContribFileName(), JSON.stringify(data, null, 2), "utf-8");
       await this.installApplication(repo_name);
-      if (argv.verbose) 
-        console.info(">>> Done.");
-      return 
+      if (argv.verbose) console.info(">>> Done.");
     },
     
     installApplication: async function(repoName) {
       let contribJson = await this.getContribData();
-      let libraryJson = contribJson.libraries.find(data => data.repo_name == repoName);
+      let libraryJson = contribJson.libraries.find(data => data.repo_name === repoName);
       if (!libraryJson)
         throw new Error("Repo for " + repoName + " is not installed as a contrib");
       
@@ -160,8 +165,8 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       let manifestApp = manifest.provides.application;
       let app = compileJson.applications.find(app => {
         if (manifestApp.name && app.name)
-          return manifestApp.name == app.name;
-        return manifestApp["class"] == app["class"];
+          return manifestApp.name === app.name;
+        return manifestApp["class"] === app["class"];
       });
       if (!app) {
         compileJson.applications.push(manifestApp);
@@ -176,7 +181,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       return await qx.tool.compiler.utils.Json.saveJsonAsync("compile.json", compileJson);
     },
 
-    __loadFromContrib: async function() {
+    __loadFromContribJson: async function() {
       // read libraries array from contrib.json 
       let contrib_json_path = process.cwd() + "/contrib.json";
       let data = fs.existsSync(contrib_json_path) ? jsonlint.parse( fs.readFileSync(contrib_json_path,"utf-8") ) : { libraries : [ ] };
@@ -198,7 +203,9 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       if( ! release_data ){
         throw new qx.tool.cli.Utils.UserError(`'${repo_name}' has no release '${tag_name}'.`);
       }
-      console.info(`Installing ${repo_name} ${tag_name}`);
+      if (!this.argv.quiet){
+        console.info(`Installing ${repo_name} ${tag_name}`);
+      }
       // download zip of release
       let url = release_data.zip_url;
       let contrib_dir = [process.cwd(), "contrib", repo_name.replace(/\//g,"_")+"_"+tag_name ];
@@ -207,7 +214,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
         if( ! fs.existsSync(dir) ) fs.mkdirSync(dir);
         return dir;
       });
-      if (this.argv.verbose) console.log(`>>> Downloading ZIP from ${url} to ${download_path}`);
+      if (this.argv.verbose) console.info(`>>> Downloading ZIP from ${url} to ${download_path}`);
       try {
         await download(url, download_path, {extract:true, strip: 1});
       } catch (e) {

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -81,7 +81,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
         console.log(`>>> We have ${num_compat_repos} contrib repositories which contain libraries compatible with qooxdoo version ${qooxdoo_version}`);
       }
 
-      if ( num_compat_repos === 0 && ! this.argv.all ) {
+      if ( num_compat_repos === 0 && ! this.argv.all && ! this.argv.quiet ) {
         console.info(
           `Currently, no contrib libraries with releases compatible with qooxdoo version ${qooxdoo_version} exist.`
         );
@@ -110,8 +110,10 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
                 }
               }
             }
-          }           
-          console.info(columnify( this.__libraries[repo], columnify_options ) );
+          };
+          if (!this.argv.quiet){
+            console.info(columnify( this.__libraries[repo], columnify_options ) );
+          }
         } else if( this.argv.verbose ) {
           console.info(`Repository ${repo} does not contain suitable contrib libraries.`);
         }
@@ -125,19 +127,19 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
           description: { maxWidth: 60 },
           installedVersion: {
             headingTransform : heading => "INSTALLED",
-            dataTransform: data => data == "false" ? "" : data
+            dataTransform: data => data === "false" ? "" : data
           },          
           latestVersion: {
             headingTransform : heading => "LATEST",
-            dataTransform: data => data == "false" ? "-" : data
+            dataTransform: data => data === "false" ? "-" : data
           },
           latestCompatible : {
             headingTransform : heading => "COMPATIBLE",
-            dataTransform: data => data == "false" ? "-" : data
+            dataTransform: data => data === "false" ? "-" : data
           }
         }
-      } 
-      let list = 
+      };
+      let list =
         this.argv.all ?
         this.__repositories :
         this.__repositories.filter( item => item.latestCompatible );
@@ -146,13 +148,14 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
         r = r.name.toLowerCase();
         return l < r ? -1 : l > r ? 1 : 0;
       });
-
-      console.info( columnify( list, columnify_options ));
-      console.info();
-      console.info( "Note on columns: LATEST: Latest release that can be installed with this CLI;" ); 
-      console.info( "                 COMPATIBLE: Latest release that is semver-compatible with the qooxdoo version used.");
-      if( ! this.argv.all ){
-        console.info( "To see all libraries, including potentially incompatible ones, use 'qx contrib list --all'.");  
+      if (!this.argv.quiet) {
+        console.info( columnify( list, columnify_options ));
+        console.info();
+        console.info( "Note on columns: LATEST: Latest release that can be installed with this CLI;" );
+        console.info( "                 COMPATIBLE: Latest release that is semver-compatible with the qooxdoo version used.");
+        if( ! this.argv.all ){
+          console.info( "To see all libraries, including potentially incompatible ones, use 'qx contrib list --all'.");
+        }
       }
       
       // save to cache
@@ -176,7 +179,6 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
     {
       let repos_cache = this.getCache().repos;
       let num_compat_repos = 0;
-      let result_repo_list = [];
       if (this.__latestCompatible[qooxdoo_version] === undefined) {
         this.__latestCompatible[qooxdoo_version] = {};
       } 
@@ -186,7 +188,6 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
         let repo_data = repos_cache.data[repo_name];
         let tag_names = repo_data.releases.list;
         let { description } = repo_data;
-        let releaseInfo = [];
         let hasCompatibleRelease = false;
         let latestVersion = false; 
         let installedVersion = false; 
@@ -195,8 +196,6 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
         for (let tag_name of tag_names) {
           let release_data = repo_data.releases.data[tag_name];
           let { prerelease, manifests } = release_data;
-          let compatible_libraries = [];
-
           // iterate over library manifests in that release
           for ( let { qx_versions, info } of manifests) {
             if (info === undefined) {
@@ -210,7 +209,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
             let name = info.name;
             let version = info.version;
             let tag_version = tag_name.replace(/v/,'');
-            if( version != tag_version ){
+            if( version !== tag_version ){
               if (this.argv.verbose) {
                 console.warn(`>>> Ignoring ${repo_name} ${tag_name}, library '${name}': mismatch between tag version '${tag_version}' and library version '${version}'.`);
               }

--- a/lib/qx/tool/cli/commands/contrib/Update.js
+++ b/lib/qx/tool/cli/commands/contrib/Update.js
@@ -118,7 +118,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
       }
 
       let num_libraries = this.getCache().num_libraries;
-      if( num_libraries ) {
+      if( num_libraries && ! argv.quiet ) {
         console.info(`Found ${num_libraries} libraries.`);
         console.info(`Run 'qx contrib list' in the root dir of your project to see which libraries are compatible.`);
       }


### PR DESCRIPTION
This allows to do `qx contrib install` or `qx contrib install <repo name>` without having to type `qx contrib update && qx contrib list` first.