### PR TITLE
Some fixes to qx create

### DIFF
--- a/lib/qx/tool/cli/commands/Command.js
+++ b/lib/qx/tool/cli/commands/Command.js
@@ -32,6 +32,11 @@ require("../Utils");
  */
 qx.Class.define("qx.tool.cli.commands.Command", {
   extend: qx.core.Object,
+
+  statics:{
+    TEMPLATE_DIR: path.join( __dirname, "../../../../../tool/cli/templates" ),
+    NODE_MODULES_DIR: path.join( __dirname, "../../../../../node_modules")
+  },
   
   construct: function(argv) {
     this.base(arguments);
@@ -282,8 +287,8 @@ qx.Class.define("qx.tool.cli.commands.Command", {
     /**
      * Awaitable wrapper around child_process.exec
      * Executes a command and return its result wrapped in a Promise.
-     * @param {String} Command with all parameters
-     * @param {Promise} Promise that resolves with the result
+     * @param cmd {String} Command with all parameters
+     * @return {Promise} Promise that resolves with the result
      */
     exec : function(cmd){
       return new Promise((resolve,reject)=>{
@@ -300,7 +305,7 @@ qx.Class.define("qx.tool.cli.commands.Command", {
      * @return {String}
      */
     getTemplateDir : function(){
-      return  path.join( __dirname, "../../../../../tool/cli/templates" );
+      return qx.tool.cli.commands.Command.TEMPLATE_DIR;
     },
     
     /**
@@ -309,8 +314,7 @@ qx.Class.define("qx.tool.cli.commands.Command", {
      * not used
      */
     getNodeModuleDir : function(){
-      return  path.join( __dirname, "../../../../../node_modules");
+      return  qx.tool.cli.commands.Command.NODE_MODULES_DIR;
     }
-    
   }
 });

--- a/lib/qx/tool/cli/commands/Create.js
+++ b/lib/qx/tool/cli/commands/Create.js
@@ -30,6 +30,7 @@ const semver = require("semver");
 const inquirer = require("inquirer");
 
 const MANIFEST_KEY_COMPAT_VERSION_RANGE = "qooxdoo-range";
+const template_vars_path = path.join(qx.tool.cli.commands.Command.TEMPLATE_DIR, "template_vars");
 
 /**
  * Create a new qooxdoo project. This will assemble the information needed to create the 
@@ -52,7 +53,7 @@ qx.Class.define("qx.tool.cli.commands.Create", {
         builder: {
           "type": {
             alias : "t",
-            describe : "Type of the application to create.",
+            describe : "Type of the application to create. Must be one of " + this.getSkeletonNames().join(", "),
             nargs: 1,
             requiresArg: true,
             type: "string"
@@ -95,6 +96,22 @@ qx.Class.define("qx.tool.cli.commands.Create", {
             });
         }
       };
+    },
+    /**
+     * Returns the names of the skeleton directories in the template folder
+     * @returns {string[]}
+     */
+    getSkeletonNames: function() {
+      let dir = path.join(qx.tool.cli.commands.Command.TEMPLATE_DIR,"skeleton");
+      return fs
+        .readdirSync(dir)
+        .filter(entry => {
+          try{
+            return fs.existsSync(path.join(dir,entry,"Manifest.tmpl.json"));
+          } catch (e) {
+            return false;
+          }
+        });
     }
   },
 
@@ -126,11 +143,11 @@ qx.Class.define("qx.tool.cli.commands.Create", {
       // get map of metdata on variables that need to be inserted in the templates
       data.template_dir = this.getTemplateDir();
       data.getLibraryVersion = this.getLibraryVersion.bind(this);
-      let template_vars_path = "../../../../../tool/cli/templates/template_vars";
-      let template_vars = require(template_vars_path)(argv,data);
+      let template_vars;
+      template_vars = require(template_vars_path)(argv, data);
 
       // prepare inquirer question data
-      for(let var_name in template_vars){
+      for(let var_name of Object.getOwnPropertyNames(template_vars)){
         let v = template_vars[var_name];
         let deflt = typeof v.default === "function" ? v.default() : v.default;
        
@@ -168,7 +185,7 @@ qx.Class.define("qx.tool.cli.commands.Create", {
       }
       
       // finalize values
-      for(let var_name in template_vars){
+      for(let var_name of Object.getOwnPropertyNames(template_vars)){
         
         let value = values[var_name];
 
@@ -230,8 +247,7 @@ qx.Class.define("qx.tool.cli.commands.Create", {
       // copy template, replacing template vars
       function traverseFileSystem(sourceDir,targetDir){
         let files = fs.readdirSync(sourceDir);
-        for (let i in files) {
-          let part = files[i];
+        for (let part of files) {
           let sourceFile = path.join(sourceDir, part);
           let stats = fs.statSync(sourceFile);
           if (stats.isFile() ) {
@@ -254,7 +270,7 @@ qx.Class.define("qx.tool.cli.commands.Create", {
               fs.copyFileSync( sourceFile, targetFile );
             }
           } else if (stats.isDirectory()) {
-            if( part == "custom" ) part = values.namespace;
+            if( part === "custom" ) part = values.namespace;
             let newTargetDir = path.join(targetDir,part);
             fs.mkdirSync(newTargetDir);
             traverseFileSystem(sourceFile,newTargetDir);

--- a/tool/cli/templates/template_vars.js
+++ b/tool/cli/templates/template_vars.js
@@ -39,26 +39,19 @@ const fs = require("fs");
  *  
  * @param argv {Object} The calling command class' yargs argv object
  * @param data {Object} Additional data
- * @param that {Object} The calling command class' "this" object, in order to be able access its methods.
- * This doesn't seem right and should be solved differently. 
  */
 module.exports = function(argv, data){
   return {
     "type" : {
       "type": "list", // doesn't support validation
-      "choices": function() {
-         // check if skeleton exists
-         let skeleton_dir = path.join( data.template_dir, "skeleton");
-         const dirs = p => fs.readdirSync(skeleton_dir).filter(f => fs.statSync(path.join(skeleton_dir, f)).isDirectory());
-         return dirs();        
-      },
+      "choices": qx.tool.cli.commands.Create.getSkeletonNames(),
       "description" : "type of the application:",
       "value" : argv.type,
       "default" : "desktop"
     },  
     "namespace" : {
       "description" : "the namespace of the application",
-      "value" : argv.applicationnamespace
+      "default" : argv.applicationnamespace.replace(/[-.]/g,"_")
     },
     "out" : {
       "description" : "the output directory for the application content (use '.' if no subdirectory should be created)",
@@ -111,7 +104,7 @@ module.exports = function(argv, data){
     "qooxdoo_range" : {
       "description" : "the semver range of qooxdoo versions that are compatible with this application",
       "default" : function() {
-        return data.qooxdoo_version;
+        return "^" + data.qooxdoo_version;
       }  
     },
     "theme": {


### PR DESCRIPTION
This fixes a number of lint warnings in `qx create`, refactors out certain file paths as static constants, and adds the automatic  listing of skeleton types to the help text/documentation. Also, previously the application namespace wasn't requested interactively. 