### PR TITLE
Here are some fixes to get demobrowser to work:

### DIFF
--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -159,6 +159,24 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
     }
  
   },
+  
+  events: {
+    /*** fired just before makes begin */
+    "startMake": "qx.event.type.Event",
+    /*** fired when application writing starts */
+    "writingApplications": "qx.event.type.Event",
+    /** fired when writing of single application starts
+     *  data: app {Application}
+     */
+    "writingApplication": "qx.event.type.Data",
+    /** fired when writing of single application is written
+     *  data: app {Application}
+     */
+    "writtenApplication": "qx.event.type.Data",
+    /*** fired after writing of all applications */
+    "writtenApplications" :"qx.event.type.Event"
+  },
+
     
   members: {
     __gauge: null,
@@ -235,9 +253,15 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           });
         }
       }
+      maker.addListener("writingApplications", (e) => this.dispatchEvent(e.clone()));
+      maker.addListener("writtenApplications", (e) => this.dispatchEvent(e.clone()));
+      maker.addListener("writingApplication",  (e) => this.dispatchEvent(e.clone()));
+      maker.addListener("writtenApplication",  (e) => this.dispatchEvent(e.clone()));
 
       var p = qx.tool.compiler.files.Utils.safeStat("source/index.html")
         .then((stat) => stat && qx.tool.compiler.Console.print("qx.tool.cli.compile.legacyFiles", "source/index.html"));
+      
+      this.fireEvent("startMake");
       
       // Simple one of make
       if (!this.argv.watch) {

--- a/lib/qx/tool/cli/commands/contrib/Publish.js
+++ b/lib/qx/tool/cli/commands/contrib/Publish.js
@@ -74,6 +74,10 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
           "verbose": {
             alias: "v",
             describe: 'Verbose logging'
+          },
+          "force": {
+            alias: "f",
+            describe: 'overrun demo check'
           }
         },
         handler: function(argv) {
@@ -158,7 +162,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
       let manifest = jsonlint.parse( fs.readFileSync(manifest_path,"utf-8") );
 
       // prevent accidental publication of demo manifest.
-      if( manifest.provides.namespace.includes(".demo") ){
+      if(!argv.force &&  manifest.provides.namespace.includes(".demo") ){
         throw new qx.tool.cli.Utils.UserError("This seems to be the contrib demo. Please go into the library directory to publish the library.");
       }
 

--- a/lib/qx/tool/compiler/app/loader-browser.tmpl.js
+++ b/lib/qx/tool/compiler/app/loader-browser.tmpl.js
@@ -5,8 +5,12 @@ if (!window.qx)
 
 qx.$$start = new Date();
 
+if (!qx.$$appRoot) 
+  qx.$$appRoot = "";
+  
 if (!qx.$$environment) 
   qx.$$environment = {};
+
 var envinfo = %{EnvSettings};
 for (var k in envinfo) 
   qx.$$environment[k] = envinfo[k];

--- a/lib/qx/tool/compiler/targets/BuildTarget.js
+++ b/lib/qx/tool/compiler/targets/BuildTarget.js
@@ -22,7 +22,7 @@
 
 require("../utils/Promisify");
 const fs = qx.tool.compiler.utils.Promisify.fs;
-const path = require("path");
+const path = require("upath");
 require("qooxdoo");
 const async = require("async");
 const util = require("../util");
@@ -85,6 +85,8 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
       var application = compileInfo.application;
       var targetUri = t._getOutputRootUri(application);
       var appRootDir = this.getApplicationRoot(application);
+      var mapTo = this.getPathMapping(path.join(appRootDir, this.getOutputDir(), "resource"));
+      var resourceUri = mapTo ? mapTo : targetUri + "resource";
       
       compileInfo.build = { 
           parts: {}
@@ -96,7 +98,8 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
                 hashValue: null,
                 modified: true
               };
-            package.uris = ["__out__:part-" + pkgId + ".js"];
+                                          
+            package.uris = ["__out__:" + t.getScriptPrefix() + "part-" + pkgId + ".js"];
           });
 
       var libraries = this.getAnalyser().getLibraries();
@@ -105,7 +108,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
         libraryLookup[library.getNamespace()] = library;
         compileInfo.configdata.libraries[library.getNamespace()] = {
           sourceUri: ".",
-          resourceUri: targetUri + "resource"
+          resourceUri: resourceUri
         };
       });
 
@@ -153,9 +156,9 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
 
       async.eachOf(compileInfo.build.parts, 
           function(part, pkgId, cb) {
-            var tmpFilename = path.join(appRootDir, t.getScriptPrefix(), "part-" + pkgId + "-tmp.js"); 
-            var partFilename = path.join(appRootDir, t.getScriptPrefix(), "part-" + pkgId + ".js");
-            var mapFilename = path.join(appRootDir, t.getScriptPrefix(), "part-" + pkgId + ".js.map"); 
+            var tmpFilename = path.join(appRootDir, t.getScriptPrefix() + "part-" + pkgId + "-tmp.js"); 
+            var partFilename = path.join(appRootDir, t.getScriptPrefix() +  "part-" + pkgId + ".js");
+            var mapFilename = path.join(appRootDir, t.getScriptPrefix() + "part-" + pkgId + ".js.map"); 
             var ws = fs.createWriteStream(tmpFilename);
             var hash = crypto.createHash('sha256');
             hash.setEncoding('hex');

--- a/lib/qx/tool/compiler/targets/SourceTarget.js
+++ b/lib/qx/tool/compiler/targets/SourceTarget.js
@@ -21,7 +21,7 @@
  * ************************************************************************/
 
 var fs = require("fs");
-var path = require("path");
+var path = require("upath");
 require("qooxdoo");
 var async = require("async");
 var util = require("../util");
@@ -53,13 +53,15 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.SourceTarget", {
     _writeApplication: function(compileInfo, cb) {
       var t = this;
       var application = compileInfo.application;
-      var outputRootUri = t._getOutputRootUri(application);
       
-      var appRoot = this.getApplicationRoot(application);
-      var mapTo = this.getPathMapping(path.join(appRoot, this.getOutputDir(), "transpiled"));
-      var sourceUri = mapTo ? mapTo : outputRootUri + "transpiled";
-      mapTo = this.getPathMapping(path.join(appRoot, this.getOutputDir(), "resource"));
-      var resourceUri = mapTo ? mapTo : outputRootUri + "resource";
+      var targetUri = t._getOutputRootUri(application);
+      var appRootDir = this.getApplicationRoot(application);
+
+
+      var mapTo = this.getPathMapping(path.join(appRootDir, this.getOutputDir(), "transpiled"));
+      var sourceUri = mapTo ? mapTo : targetUri + "transpiled";
+      mapTo = this.getPathMapping(path.join(appRootDir, this.getOutputDir(), "resource"));
+      var resourceUri = mapTo ? mapTo : targetUri + "resource";
       
 
       var libraries = this.getAnalyser().getLibraries();

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -790,7 +790,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
               let pos = name.lastIndexOf('/');
               if (pos > -1)
                 name = name.substring(pos + 1);
-              var ws = fs.createWriteStream(path.join(appRootDir, t.getScriptPrefix(), name));
+              var ws = fs.createWriteStream(path.join(appRootDir, t.getScriptPrefix() + name));
               ws.write(data);
               t._writeBootJs(compileInfo, ws, function(err) {
                 ws.end();


### PR DESCRIPTION
1. Extend Compile.js to through some of the maker events so that you can listen to them in compile.js.
2. set qx.$$appRoot in template if not set
3. Targets:  Some fixes for getScriptPrefix. This was not handled correct everywhere
4. BuildTarget.js: Enable path mapping for resources.