### PR TITLE
Fix for #270

### DIFF
--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -36,7 +36,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
   statics: {
     getYargsCommand: function() {
       return {
-        command: 'install [repository]',
+        command: 'install [contrib_uri]',
         describe: 'installs the latest compatible release of a contrib library (as per Manifest.json). Use "-r <release tag>" to install a particular release.',
         builder: {
           "release" : {
@@ -79,7 +79,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
 
       if ( repos_cache.list.length === 0 ){
         if (!this.argv.quiet) {
-          console.info("Updating cache...");
+          console.info(">>> Updating cache...");
         }
         this.clearCache();
         // implicit update
@@ -88,7 +88,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
         repos_cache = this.getCache().repos;
       }
 
-      if (!argv.repository) {
+      if (!argv.contrib_uri) {
         await this.__loadFromContribJson();
         return;
       }
@@ -96,20 +96,23 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       let qooxdoo_version = await this.getUserQxVersion();
       if(argv.verbose) console.info(`>>> qooxdoo version:  ${qooxdoo_version}`);
      
-      // has a repository name been given?
-      if (!argv.repository) {
-        throw new qx.tool.cli.Utils.UserError("No repo name given");
+      // has a contrib_uri name been given?
+      if (!argv.contrib_uri) {
+        throw new qx.tool.cli.Utils.UserError("No contrib resource identifier given");
       }
-      let repo_name = argv.repository;
+      // currently, the contrib uri is github_username/repo_name[/path/to/repo].
+      let parts = argv.contrib_uri.split(/\//);
+      let repo_name = parts.slice(0,2).join('/');
+      let contrib_path = parts.length > 2 ? parts.slice(2).join('/') : "";
       if( ! this.getCache().repos.data[repo_name] ){
-        throw new qx.tool.cli.Utils.UserError(`'${repo_name}' does not exist or is not a contrib library.`);
+        throw new qx.tool.cli.Utils.UserError(`A contrib repository '${repo_name}' cannot be found.`);
       }
       // get compatible tag name unless a release name has been given
       let tag_name = argv.release;
       if ( ! tag_name ){
         if ( this.getCache().compat[qooxdoo_version] === undefined ){
           if (!this.argv.quiet) {
-            console.info("Updating cache...");
+            console.info(">>> Updating cache...");
           }
           await (new qx.tool.cli.commands.contrib.List({quiet:true})).process();
           // reload cache from disk
@@ -128,36 +131,58 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
 
       // iterate over contained libraries
       let library_elem = null;
+      let found = false;
       for( let { info, path:filename } of release_data.manifests ) {
-        // does the repository name already exist?
+        let current_download_path = download_path;
+
+        if (contrib_path) {
+          // if a path component exists, only install the contrib in this path
+          if (path.dirname(filename) !== contrib_path) continue;
+          current_download_path = path.join(download_path, contrib_path);
+        } else if (path.dirname(filename) !== ".") {
+          // else, skip if no manifest exists in the root of the repo
+          continue;
+        }
+        found = true;
+        // does the contrib_uri name already exist?
         let index = data.libraries.findIndex((elem)=>{
-          return elem.repo_name === repo_name
-            && elem.library_name === info.name;
+          // backwards-compatibility, can eventually be removed:
+          if (elem.repo_name) {
+            return elem.repo_name === repo_name
+              && elem.library_name === info.name;
+          }
+          return elem.uri === argv.contrib_uri;
         });
         library_elem = {
           library_name : info.name,
           library_version : info.version,
-          repo_name : repo_name,
+          uri : argv.contrib_uri,
           repo_tag : tag_name,
-          path : path.relative(process.cwd(), path.join(download_path, path.dirname(filename)))
+          path : path.relative(process.cwd(), current_download_path)
         };
-        if( index >= 0 ){
+        if (index >= 0) {
           data.libraries[index]=library_elem;
-          if (! argv.quiet) console.info(`Updating already existing config.json entry '${info.name}'.`);
+          if (! argv.quiet) console.info(`>>> Updating already existing config.json entry for'${argv.contrib_uri}'.`);
         } else {
           data.libraries.push(library_elem);
         }
+        if (!this.argv.quiet){
+          console.info(`>>> Installed ${info.name} (${argv.contrib_uri}, ${tag_name})`);
+        }
+      }
+      if (!found) {
+        throw new qx.tool.cli.Utils.UserError(`The contrib library identified by '${argv.contrib_uri}' could not be found.`);
       }
       await fs.writeFileAsync(this.getContribFileName(), JSON.stringify(data, null, 2), "utf-8");
-      await this.installApplication(repo_name);
+      await this.installApplication(argv.contrib_uri);
       if (argv.verbose) console.info(">>> Done.");
     },
     
-    installApplication: async function(repoName) {
+    installApplication: async function(uri) {
       let contribJson = await this.getContribData();
-      let libraryJson = contribJson.libraries.find(data => data.repo_name === repoName);
+      let libraryJson = contribJson.libraries.find(data => data.uri === uri);
       if (!libraryJson)
-        throw new Error("Repo for " + repoName + " is not installed as a contrib");
+        throw new Error("Contrib with identifier '" + uri + "' is not installed.");
       
       let manifest = await qx.tool.compiler.utils.Json.loadJsonAsync(path.join(libraryJson.path, "Manifest.json"), "utf8");
       if (!manifest.provides || !manifest.provides.application) {
@@ -208,9 +233,6 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       if( ! release_data ){
         throw new qx.tool.cli.Utils.UserError(`'${repo_name}' has no release '${tag_name}'.`);
       }
-      if (!this.argv.quiet){
-        console.info(`Installing ${repo_name} ${tag_name}`);
-      }
       // download zip of release
       let url = release_data.zip_url;
       let contrib_dir = [process.cwd(), "contrib", repo_name.replace(/\//g,"_")+"_"+tag_name ];
@@ -219,11 +241,15 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
         if( ! fs.existsSync(dir) ) fs.mkdirSync(dir);
         return dir;
       });
-      if (this.argv.verbose) console.info(`>>> Downloading ZIP from ${url} to ${download_path}`);
-      try {
-        await download(url, download_path, {extract:true, strip: 1});
-      } catch (e) {
-        throw e;
+      if (fs.existsSync(download_path)){
+        if (this.argv.verbose) console.info(`>>> Repo has already been downloaded to ${download_path}. To download again, execute 'qx clean'.`);
+      } else {
+        if (this.argv.verbose) console.info(`>>> Downloading ZIP from ${url} to ${download_path}`);
+        try {
+          await download(url, download_path, {extract:true, strip: 1});
+        } catch (e) {
+          throw e;
+        }
       }
       return { release_data, download_path };
     }

--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -183,7 +183,6 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       let libraryJson = contribJson.libraries.find(data => data.uri === uri);
       if (!libraryJson)
         throw new Error("Contrib with identifier '" + uri + "' is not installed.");
-      
       let manifest = await qx.tool.compiler.utils.Json.loadJsonAsync(path.join(libraryJson.path, "Manifest.json"), "utf8");
       if (!manifest.provides || !manifest.provides.application) {
         if (this.argv.verbose) 
@@ -236,15 +235,21 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       // download zip of release
       let url = release_data.zip_url;
       let contrib_dir = [process.cwd(), "contrib", repo_name.replace(/\//g,"_")+"_"+tag_name ];
+      let dir_exists;
       let download_path = contrib_dir.reduce((prev,current)=>{
         let dir = prev + path.sep + current;
-        if( ! fs.existsSync(dir) ) fs.mkdirSync(dir);
+        if( ! fs.existsSync(dir) ){
+          fs.mkdirSync(dir);
+          dir_exists = false;
+        } else {
+          dir_exists = true;
+        }
         return dir;
       });
-      if (fs.existsSync(download_path)){
-        if (this.argv.verbose) console.info(`>>> Repo has already been downloaded to ${download_path}. To download again, execute 'qx clean'.`);
+      if (dir_exists){
+        if (this.argv.verbose) console.info(`>>> Contrib repository has already been downloaded to ${download_path}. To download again, execute 'qx clean'.`);
       } else {
-        if (this.argv.verbose) console.info(`>>> Downloading ZIP from ${url} to ${download_path}`);
+        if (this.argv.verbose) console.info(`>>> Downloading contrib repository from ${url} to ${download_path}`);
         try {
           await download(url, download_path, {extract:true, strip: 1});
         } catch (e) {

--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -146,18 +146,19 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
         found = true;
         // does the contrib_uri name already exist?
         let index = data.libraries.findIndex((elem)=>{
-          // backwards-compatibility, can eventually be removed:
-          if (elem.repo_name) {
-            return elem.repo_name === repo_name
-              && elem.library_name === info.name;
+          if (elem.uri) {
+            return elem.uri === argv.contrib_uri;
           }
-          return elem.uri === argv.contrib_uri;
+          // backwards-compatibility, can eventually be removed:
+          return elem.repo_name === repo_name
+            && elem.library_name === info.name;
         });
         library_elem = {
           library_name : info.name,
           library_version : info.version,
           uri : argv.contrib_uri,
-          repo_tag : tag_name,
+          repo_name, // todo: should eventually be removed in favor of a uri-only resolution
+          repo_tag : tag_name, // todo: replace by real version string
           path : path.relative(process.cwd(), current_download_path)
         };
         if (index >= 0) {
@@ -228,8 +229,11 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
     __download: async function(repo_name, tag_name) {
       // get release data
       let repo_data = this.getCache().repos.data[repo_name];
+      if (! repo_data){
+        throw new qx.tool.cli.Utils.UserError(`A contrib repository '${repo_name}' cannot be found.`);
+      }
       let release_data = repo_data.releases.data[tag_name];
-      if( ! release_data ){
+      if (! release_data){
         throw new qx.tool.cli.Utils.UserError(`'${repo_name}' has no release '${tag_name}'.`);
       }
       // download zip of release
@@ -247,9 +251,9 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
         return dir;
       });
       if (dir_exists){
-        if (this.argv.verbose) console.info(`>>> Contrib repository has already been downloaded to ${download_path}. To download again, execute 'qx clean'.`);
+        if (this.argv.verbose) console.info(`>>> Contrib repository '${repo_name}' has already been downloaded to ${download_path}. To download again, execute 'qx clean'.`);
       } else {
-        if (this.argv.verbose) console.info(`>>> Downloading contrib repository from ${url} to ${download_path}`);
+        if (this.argv.verbose) console.info(`>>> Downloading contrib repository '${repo_name}' from ${url} to ${download_path}`);
         try {
           await download(url, download_path, {extract:true, strip: 1});
         } catch (e) {

--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -168,7 +168,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
           data.libraries.push(library_elem);
         }
         if (!this.argv.quiet){
-          console.info(`>>> Installed ${info.name} (${argv.contrib_uri}, ${tag_name})`);
+          console.info(`>>> Installed ${info.name} (${argv.contrib_uri}, ${info.version})`);
         }
       }
       if (!found) {

--- a/lib/qx/tool/cli/commands/contrib/Update.js
+++ b/lib/qx/tool/cli/commands/contrib/Update.js
@@ -162,7 +162,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
           let name = repo.full_name;
 
           // if a repository name has been given, only update this repo
-          if (update_repo_only && name != update_repo_only) continue;
+          if (update_repo_only && name !== update_repo_only) continue;
           if (argv.verbose) console.info(`### Found ${name} ...`);
           names.push(name);
           let repository = new Repository(name, auth);
@@ -212,12 +212,15 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
               }
               // we have a list of Manifest.json paths!
               if (data.contribs && data.contribs instanceof Array) {
-                manifests = data.libraries || data.contribs; // data.contribs is deprecated
-              }            
+                console.warn(`!!! qooxdoo.json/contribs is deprecated, use qooxdoo.json/libraries instead`);
+                manifests = data.contribs;
+              } else if (data.libraries && data.libraries instanceof Array) {
+                manifests = data.libraries;
+              }
             } catch (e) {
-              // no Qooxdoo.json
+              // no qooxdoo.json
               if (e.message.match(/404/)) {
-                if (argv.verbose) console.warn(`!!! File does not exist.`);
+                if (argv.verbose) console.log(`!!! File does not exist.`);
               } else {
                 if (argv.verbose) console.warn(`!!! Error: ${e.message}`);
               }
@@ -227,7 +230,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
             for (let [index, { path }] of manifests.entries()) {
               let manifest_data;
               if (path !== "Manifest.json") {
-                if (path.substr(0, 2) == "./") {
+                if (path.substr(0, 2) === "./") {
                   path = path.substr(2);
                 }
                 path += "/Manifest.json";

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1863,7 +1863,7 @@
     },
     "es6-promise": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
       "integrity": "sha1-lu258v2wGZWCKyY92KratnSBgbw="
     },
     "es6-promisify": {
@@ -5417,7 +5417,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "requires": {
         "caller-path": "^0.1.0",
@@ -5600,7 +5600,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
             "amdefine": ">=0.0.4"
@@ -5882,7 +5882,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -5890,7 +5890,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -5911,7 +5911,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-indent": {
@@ -6032,7 +6032,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
         "block-stream": "*",
@@ -6061,7 +6061,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -6334,7 +6334,7 @@
     },
     "utf8": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
       "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
     },
     "util-deprecate": {
@@ -6493,7 +6493,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/test/test.linux.sh
+++ b/test/test.linux.sh
@@ -9,9 +9,11 @@ qx contrib list    -v|| exit $?
 qx contrib install oetiker/UploadWidget --release v1.0.0 -v || exit $?
 qx contrib install cboulanger/qx-contrib-Dialog --release v1.3.0-beta.3 -v || exit $?
 qx contrib install johnspackman/UploadMgr --release v1.0.0 -v || exit $?
+qx contrib install ergobyte/qookery/qookeryace -v || exit $?
+qx contrib install ergobyte/qookery/qookerymaps -v || exit $?
 qx compile -v --clean || exit $?
 node source-output/myapp/myapp.js || exit $?
-rm -rf contrib  || exit $?
+qx clean || exit $?
 qx contrib install -v || exit $?
 qx compile -v --clean || exit $?
 node source-output/myapp/myapp.js

--- a/test/test.win32.cmd
+++ b/test/test.win32.cmd
@@ -10,10 +10,12 @@ call qx contrib list -v || EXIT /B 1
 call qx contrib install oetiker/UploadWidget --release v1.0.0 -v || EXIT /B 1
 call qx contrib install cboulanger/qx-contrib-Dialog --release v1.3.0-beta.3 -v || EXIT /B 1
 call qx contrib install johnspackman/UploadMgr --release v1.0.0 -v || EXIT /B 1
+call contrib install ergobyte/qookery/qookeryace -v || EXIT /B 1
+call contrib install ergobyte/qookery/qookerymaps -v || EXIT /B 1
 call qx compile -v --clean || EXIT /B 1
 call node source-output\myapp\myapp.js || EXIT /B 1
 :: test reinstall contrib
-rmdir /Q /S contrib
+call qx clean
 call qx contrib install  -v || EXIT /B 1
 call qx compile -v --clean || EXIT /B 1
 call node source-output\myapp\myapp.js || EXIT /B 1


### PR DESCRIPTION
With this change, the following is possible:
```
qx contrib install ergobyte/qookery/qookeryace --verbose
>>> qooxdoo version:  6.0.0-alpha
>>> Repo has already been downloaded to /Users/cboulanger/Code/qooxdoo-compiler/foo/contrib/ergobyte_qookery_v0.5.0. To download again, execute 'qx clean'.
>>> Updating already existing config.json entry 'ergobyte/qookery/qookeryace'.
>>> Installed Qookery Ace (ergobyte/qookery/qookeryace, v0.5.0)
>>> No application to install.
>>> Done.
```