### PR TITLE
fixes a bug where chokidar no longer reports changes on relative paths, causing `--watch` to never recompile

### DIFF
--- a/lib/qx/tool/cli/Watch.js
+++ b/lib/qx/tool/cli/Watch.js
@@ -48,6 +48,7 @@ qx.Class.define("qx.tool.cli.Watch", {
   members: {
     __runningPromise: null,
     __applications: null,
+    __watcherReady: false,
     
     start: function() {
       if (this.__runningPromise)
@@ -81,14 +82,15 @@ qx.Class.define("qx.tool.cli.Watch", {
         applications.push(data);
       }.bind(this));
       var confirmed = [];
-      Promise.all(dirs.map((dir) => new Promise((resolve, reject) => {
+      Promise.all(dirs.map(dir => new Promise((resolve, reject) => {
+        dir = path.resolve(dir);
         fs.stat(dir, function(err) {
           if (err)
             return err.code == "ENOENT" ? resolve() : reject(err);
             
           // On case insensitive (but case preserving) filing systems, qx.tool.compiler.files.Utils.correctCase 
           // is needed corrects because chokidar needs the correct case in order to detect changes. 
-          qx.tool.compiler.files.Utils.correctCase(dir).then((dir) => {
+          qx.tool.compiler.files.Utils.correctCase(dir).then(dir => {
             confirmed.push(dir);
             resolve();
           });
@@ -100,7 +102,10 @@ qx.Class.define("qx.tool.cli.Watch", {
         watcher.on("change", (filename) => this.__onFileChange("change", filename));
         watcher.on("add", (filename) => this.__onFileChange("add", filename));
         watcher.on("unlink", (filename) => this.__onFileChange("unlink", filename));
-        this.__make();
+        watcher.on("ready", () => {
+          this.__watcherReady = true;
+          this.__make();
+        });
       });
     },
     
@@ -180,6 +185,9 @@ qx.Class.define("qx.tool.cli.Watch", {
     },
     
     __onFileChange: function(type, filename) {
+      if (!this.__watcherReady)
+        return;
+      
       var t = this;
       var outOfDate = false;
 

--- a/lib/qx/tool/compiler/files/Utils.js
+++ b/lib/qx/tool/compiler/files/Utils.js
@@ -227,7 +227,7 @@ qx.Class.define("qx.tool.compiler.files.Utils", {
         drivePrefix = dir.substring(0, 2);
         dir = dir.substring(2);
       }
-      dir = dir.replace("\\", "/");
+      dir = dir.replace(/\\/g, "/");
       var segs = dir.split('/');
       if (!segs.length)
         return drivePrefix + dir;
@@ -244,7 +244,7 @@ qx.Class.define("qx.tool.compiler.files.Utils", {
       
       function bumpToNext(nextSeg) {
         index++;
-        if (currentDir.length)
+        if (currentDir.length && currentDir !== "/")
           currentDir = currentDir + "/";
         currentDir = currentDir + nextSeg;
         return next();
@@ -252,6 +252,8 @@ qx.Class.define("qx.tool.compiler.files.Utils", {
       
       function next() {
         if (index == segs.length) {
+          if (process.platform === 'win32')
+            currentDir = currentDir.replace(/\//g, "\\");
           return Promise.resolve(drivePrefix + currentDir);
         }
         


### PR DESCRIPTION
FWIW it's possible that this may only affect Node v11+