### PR TITLE
Trim library output

### DIFF
--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -147,6 +147,11 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           "warnAsError": {
             alias: "w",
             describe: "handle warnings as error"
+          },
+          "write-library-info": {
+            describe: "Write library information to the script, for reflection",
+            type: "boolean",
+            default: true
           }
 
           
@@ -390,6 +395,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       if (data.target.writeCompileInfo) {
         target.setWriteCompileInfo(true); 
       }
+      target.setWriteLibraryInfo(this.argv.writeLibraryInfo);
       maker.setTarget(target);
 
       maker.setLocales(data.locales||[ "en" ]);

--- a/lib/qx/tool/compiler/app/Application.js
+++ b/lib/qx/tool/compiler/app/Application.js
@@ -178,6 +178,7 @@ qx.Class.define("qx.tool.compiler.app.Application", {
   members: {
     __loadDeps: null,
     __parts: null,
+    __requiredLibs: null,
     __fatalCompileErrors: null,
 
     /**
@@ -492,6 +493,11 @@ qx.Class.define("qx.tool.compiler.app.Application", {
        */
 
       this.__loadDeps = allDeps.toArray();
+      
+      var requiredLibs = {};
+      this.__loadDeps.forEach(classname => requiredLibs[db.classInfo[classname].libraryName] = true);
+      this.__requiredLibs = Object.keys(requiredLibs);
+      
       this.__partsDeps = parts;
       this.__fatalCompileErrors = fatalCompileErrors.length ? fatalCompileErrors : null;
     },
@@ -539,6 +545,15 @@ qx.Class.define("qx.tool.compiler.app.Application", {
      */
     getPartsDependencies: function() {
       return this.__partsDeps;
+    },
+    
+    /**
+     * Returns a list of library names which are required by the application
+     * 
+     * @returns {String[]}
+     */
+    getRequiredLibraries: function() {
+      return this.__requiredLibs;
     },
 
     /**

--- a/lib/qx/tool/compiler/files/Utils.js
+++ b/lib/qx/tool/compiler/files/Utils.js
@@ -245,7 +245,7 @@ qx.Class.define("qx.tool.compiler.files.Utils", {
       function bumpToNext(nextSeg) {
         index++;
         if (currentDir.length && currentDir !== "/") {
-          currentDir +=  + "/";
+          currentDir += "/";
         }  
         currentDir = currentDir + nextSeg;
         return next();

--- a/lib/qx/tool/compiler/targets/SourceTarget.js
+++ b/lib/qx/tool/compiler/targets/SourceTarget.js
@@ -59,15 +59,11 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.SourceTarget", {
       var resourceUri = mapTo ? mapTo : targetUri + "resource";
       
 
-      var libraries = this.getAnalyser().getLibraries();
-      var libraryLookup = {};
-      libraries.forEach(function(library) {
-        libraryLookup[library.getNamespace()] = library;
-
-        compileInfo.configdata.libraries[library.getNamespace()] = {
-          sourceUri: sourceUri,
-          resourceUri: resourceUri
-        };
+      application.getRequiredLibraries().forEach(ns => {
+        compileInfo.configdata.libraries[ns] = {
+            sourceUri: sourceUri,
+            resourceUri: resourceUri
+          };
       });
 
       var _arguments = arguments;

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -128,6 +128,15 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
       init: false,
       nullable: false,
       check: "Boolean"
+    },
+    
+    /**
+     * Whether to write information about the libraries into the boot script
+     */
+    writeLibraryInfo: {
+      init: true,
+      nullable: false,
+      check: "Boolean"
     }
 
   },
@@ -218,16 +227,11 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
     _syncAssets: async function(compileInfo) {
       var t = this;
 
+      const analyser = compileInfo.application.getAnalyser();
       await new Promise((resolve, reject) => {
-        var libraries = this.getAnalyser().getLibraries();
-        var libraryLookup = {};
-        libraries.forEach(function(library) {
-          libraryLookup[library.getNamespace()] = library;
-        });
-        
         var queue = async.queue(
             function (asset, cb) {
-              var library = libraryLookup[asset.libraryName];
+              var library = analyser.findLibrary(asset.libraryName);
               qx.tool.compiler.files.Utils.sync(
                   library.getRootDir() + "/" + library.getResourcePath() + "/" + asset.filename,
                   path.join(t.getOutputDir(), "resource", asset.filename))
@@ -366,8 +370,11 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
       var libraryInfoMap = {};
       var appClassname = application.getClassName();
       var library = compileInfo.library = analyser.getLibraryFromClassname(appClassname);
+      const requiredLibs = application.getRequiredLibraries();
       var namespace = compileInfo.namespace = library.getNamespace();
-      libraryInfoMap[namespace] = library.getLibraryInfo();
+      if (this.isWriteLibraryInfo()) {
+        libraryInfoMap[namespace] = library.getLibraryInfo();
+      }
       // Root of the application & URI
       var appRootDir = this.getApplicationRoot(application);
 
@@ -443,9 +450,11 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
             configdata.loader.packages[0].uris.unshift("__out__:" + t.getScriptPrefix() + "polyfill.js");
             configdata.loader.packages[0].uris.unshift("__out__:" + t.getScriptPrefix() + "resources.js");
   
-            analyser.getLibraries().forEach(function (library) {
-              var libnamespace = library.getNamespace();
-              libraryInfoMap[libnamespace] = library.getLibraryInfo();
+            requiredLibs.forEach(libnamespace => {
+              var library = analyser.findLibrary(libnamespace);
+              if (this.isWriteLibraryInfo()) {
+                libraryInfoMap[libnamespace] = library.getLibraryInfo();
+              }
               var arr = library.getAddScript();
               if (arr) {
                 arr.forEach(path => configdata.urisBefore.push(libnamespace + ":" + path));
@@ -479,7 +488,8 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
               new Promise((resolve, reject) => {
                 var promises = [];
                 var fontCntr = 0;
-                analyser.getLibraries().forEach(library => {
+                requiredLibs.forEach(libnamespace => {
+                  var library = analyser.findLibrary(libnamespace);
                   var fonts = library.getWebFonts();
                   if (!fonts) {
                     return;
@@ -696,7 +706,8 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
       var promises = [];
       t.getLocales().forEach(function(localeId) {
         pkgdata.translations[localeId] = {};
-        analyser.getLibraries().forEach(function(library) {
+        compileInfo.application.getRequiredLibraries().forEach(function(libnamespace) {
+          var library = analyser.findLibrary(libnamespace);
           promises.push(
             analyser.getTranslation(library, localeId)
               .then(translation => {


### PR DESCRIPTION
excludes libraries which are known to the compiler but not actually used by the application from the compile process; this reduces the data written to `boot.js` and will avoid processing unneeded resources and webfonts