### PR TITLE
Auto detect `qx.$$appRoot` and make absolute

### DIFF
--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -153,8 +153,6 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
             type: "boolean",
             default: true
           }
-
-          
         },
         handler: function(argv) {
           return new qx.tool.cli.commands.Compile(argv)

--- a/lib/qx/tool/cli/commands/Serve.js
+++ b/lib/qx/tool/cli/commands/Serve.js
@@ -104,10 +104,15 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
             describe: "Deletes the target dir before compile",
             type: "boolean"
           },
-          "listenPort": {
+          "listen-port": {
             describe: "The port for the web browser to listen on",
             type: "number",
             default: 8080
+          },
+          "write-library-info": {
+            describe: "Write library information to the script, for reflection",
+            type: "boolean",
+            default: true
           }
         },
         handler   : function(argv) {

--- a/lib/qx/tool/compiler/app/loader-browser.tmpl.js
+++ b/lib/qx/tool/compiler/app/loader-browser.tmpl.js
@@ -5,8 +5,41 @@ if (!window.qx)
 
 qx.$$start = new Date();
 
-if (!qx.$$appRoot) 
-  qx.$$appRoot = "";
+var strBase = null;
+var pos;
+var bootScriptElement = document.currentScript; // Everything except IE11 https://caniuse.com/#feat=document-currentscript
+if (!bootScriptElement) {
+  var scripts = document.getElementsByTagName('script');
+  bootScriptElement = scripts[scripts.length - 1];
+}
+if (bootScriptElement) {
+  strBase = bootScriptElement.src;
+  pos = strBase.indexOf('?');
+  if (pos > -1)
+    strBase = strBase.substring(0, pos);
+  pos = strBase.lastIndexOf('/');
+  if (pos > -1) {
+    strBase = strBase.substring(0, pos + 1);
+  } else {
+    strBase = "";
+  }
+}
+if (!strBase) {
+  strBase = document.location.href;
+  pos = strBase.lastIndexOf('/');
+  if (pos > -1) {
+    strBase = strBase.substring(0, pos + 1);
+  } else if (strBase[strBase.length - 1] != '/') {
+    strBase += "/";
+  }
+  if (qx.$$appRoot) {
+    strBase += qx.$$appRoot;
+    if (strBase[strBase.length - 1] != '/') {
+      strBase += "/";
+    }
+  }
+}
+qx.$$appRoot = strBase;
   
 if (!qx.$$environment) 
   qx.$$environment = {};

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -400,7 +400,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
           },
           "libraries": {
             "__out__": {
-              "sourceUri": application.getSourceUri()||"."
+              "sourceUri": application.getSourceUri()||""
             }
           },
           "resources": {},
@@ -883,13 +883,17 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
       var resDir = this.getApplicationRoot(application);
 
       let writeIndexHtml = async (appRootDir, writingIndexToRoot) => {
-        let appRoot = writingIndexToRoot ? t.getProjectDir(application) + "/" : "";
-        let bootJs =
-          "  <script type=\"text/javascript\">\n" +
-          "    if (!window.qx) window.qx = {};\n" +
-          "    qx.$$$appRoot = \"" + appRoot + "\";\n" +
-          "  </script>\n" +
-          "  <script type=\"text/javascript\" src=\"" + appRoot + t.getScriptPrefix() + "boot.js\"></script>\n";
+        let appRoot = "";
+        let bootJs = "";
+        if (writingIndexToRoot) {
+          appRoot = t.getProjectDir(application) + "/";
+          bootJs = "  <script type=\"text/javascript\">\n" +
+            "    if (!window.qx)\n" +
+            "      window.qx = {};\n" +
+            "    qx.$$$appRoot = \"" + appRoot + "\";\n" +
+            "  </script>\n";
+        }
+        bootJs += "  <script type=\"text/javascript\" src=\"" + appRoot + t.getScriptPrefix() + "boot.js\"></script>\n";
 
         let defaultIndexHtml =
             "<!DOCTYPE html>\n" +


### PR DESCRIPTION
Makes the boot loader convert `qx.$$appRoot` into an absolute path and auto-detect the `qx.$$appRoot` - this allows a web page to add just `<script src="/path/to/boot.js"></script>` and wherever that is, the app will load.