### PR TITLE
Fix missing serve property

### DIFF
--- a/lib/qx/tool/cli/commands/Serve.js
+++ b/lib/qx/tool/cli/commands/Serve.js
@@ -179,10 +179,10 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
      * @Override
      */
     _mergeArguments: function(parsedArgs, config, contribConfig) {
-      this.base(arguments, parsedArgs, config, contribConfig);
       if (!config.serve) {
         config.serve = {};
       }
+      this.base(arguments, parsedArgs, config, contribConfig);       
       config.serve.listenPort = config.serve.listenPort||this.argv.listenPort;
       return config;
     }


### PR DESCRIPTION
This fixes a bug that occurs if the config object does not have a serve property.