### PR TITLE
fixes a bug where qooxdoo can be added twice to the list of libraries;

### DIFF
--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -320,7 +320,15 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
         }
       }
       maker.addListener("writingApplications", e => this.dispatchEvent(e.clone()));
-      maker.addListener("writtenApplications", e => this.dispatchEvent(e.clone()));
+      maker.addListener("writtenApplications", e => {
+        this.dispatchEvent(e.clone());
+        if (this.argv.verbose) {
+          console.log("\nCompleted all applications, libraries used are:");
+          maker.getAnalyser().getLibraries().forEach(lib => {
+            console.log("    " + lib.getRootDir());
+          });
+        }
+      });
       maker.addListener("writingApplication", e => this.dispatchEvent(e.clone()));
       maker.addListener("writtenApplication", e => this.dispatchEvent(e.clone()));
       analyser.addListener("compilingClass", e => this.dispatchEvent(e.clone()));
@@ -576,9 +584,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       }
       
       const addLibraryAsync = qx.tool.compiler.utils.Promisify.promisify(maker.addLibrary, maker);
-      data.libraries.forEach(async libData => {
-        await addLibraryAsync(libData);
-      });
+      await qx.Promise.all(data.libraries.map(libData => addLibraryAsync(libData)));
       
       // Search for Qooxdoo library if not already provided
       var qxLib = maker.getAnalyser().findLibrary("qx");

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -816,8 +816,8 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
             };
           var outputDir = path.join(appRootDir, t.getScriptPrefix());
 
-          qx.tool.compiler.utils.Json.writeJsonAsync(path.join(outputDir, "compile-info.json"), MAP)
-            .then(() => qx.tool.compiler.utils.Json.writeJsonAsync(path.join(outputDir, "resources.json"), compileInfo.pkgdata))
+          qx.tool.compiler.utils.Json.saveJsonAsync(path.join(outputDir, "compile-info.json"), MAP)
+            .then(() => qx.tool.compiler.utils.Json.saveJsonAsync(path.join(outputDir, "resources.json"), compileInfo.pkgdata))
             .then(resolve)
             .catch(reject);
         })


### PR DESCRIPTION
adds output which lists the paths to libraries which were used (requires `--verbose`)