### PR TITLE
Fix env vars regression for targets

### DIFF
--- a/lib/qx/tool/cli.js
+++ b/lib/qx/tool/cli.js
@@ -30,6 +30,7 @@ require("./cli/commands/Contrib.js");
 require("./cli/commands/Create.js");
 require("./cli/commands/Lint.js");
 require("./cli/commands/MConfig.js");
+require("./cli/commands/Serve.js");
 require("./cli/commands/Upgrade.js");
 require("./cli/commands/add/Class.js");
 require("./cli/commands/add/Script.js");

--- a/lib/qx/tool/cli/commands/Command.js
+++ b/lib/qx/tool/cli/commands/Command.js
@@ -322,6 +322,26 @@ qx.Class.define("qx.tool.cli.commands.Command", {
      */
     getNodeModuleDir : function() {
       return qx.tool.cli.commands.Command.NODE_MODULES_DIR;
+    },
+    
+    /**
+     * Detects whether the command line explicit set an option (as opposed to yargs
+     * providing a default value).  Note that this does not handle aliases, use the
+     * actual, full option name.
+     * 
+     * @param option {String} the name of the option, eg "listen-port"
+     * @return {Boolean}
+     */
+    isExplicitArg(option) {
+      function searchForOption(option) {
+        return process.argv.indexOf(option) > -1;
+      }
+
+      if (searchForOption(`-${option}`) || searchForOption(`--${option}`)) {
+        return true;
+      }
+
+      return false;
     }
   }
 });

--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -35,7 +35,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
   include: [qx.tool.cli.commands.MConfig],
 
   statics: {
-    
+
     getYargsCommand: function() {
       return {
         command   : "compile [configFile]",
@@ -164,9 +164,9 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
         }
       };
     }
- 
+
   },
-  
+
   events: {
 
     /*** fired when application writing starts */
@@ -182,24 +182,24 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
     /*** fired after writing of all applications */
     "writtenApplications" :"qx.event.type.Event",
 
-    /** 
+    /**
      * Fired when a class is about to be compiled; data is a map:
-     * 
-     * dbClassInfo: {Object} the newly populated class info 
-     * oldDbClassInfo: {Object} the previous populated class info 
+     *
+     * dbClassInfo: {Object} the newly populated class info
+     * oldDbClassInfo: {Object} the previous populated class info
      * classFile - {ClassFile} the qx.tool.compiler.ClassFile instance
      */
     "compilingClass": "qx.event.type.Data",
-    
-    /** 
+
+    /**
      * Fired when a class is compiled; data is a map:
-     * dbClassInfo: {Object} the newly populated class info 
-     * oldDbClassInfo: {Object} the previous populated class info 
+     * dbClassInfo: {Object} the newly populated class info
+     * oldDbClassInfo: {Object} the previous populated class info
      * classFile - {ClassFile} the qx.tool.compiler.ClassFile instance
      */
     "compiledClass": "qx.event.type.Data",
 
-    /** 
+    /**
      * Fired when the database is been saved
      * database: {Object} the database to save
      */
@@ -207,35 +207,35 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
 
     /**
      * Fired after all enviroment data is collected
-     *  application {qx.tool.compiler.app.Application} the app 
+     *  application {qx.tool.compiler.app.Application} the app
      *  enviroment: {Object} enviroment data
      */
     "checkEnvironment": "qx.event.type.Data",
 
     /**
      * Fired when making of apps begins
-    */ 
+    */
     "making": "qx.event.type.Event",
 
     /**
-     * Fired when making of apps restarts because of 
+     * Fired when making of apps restarts because of
      * changes
-    */ 
+    */
     "remaking": "qx.event.type.Event",
 
     /**
      * Fired when making of apps is done.
-    */ 
+    */
     "made": "qx.event.type.Event"
 
   },
 
-    
+
   members: {
     __gauge: null,
     __maker: null,
     __config: null,
-    
+
     _getMaker: function() {
       return this.__maker;
     },
@@ -247,33 +247,33 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
      */
     process: async function() {
       if (this.argv["machine-readable"]) {
-        qx.tool.compiler.Console.getInstance().setMachineReadable(true); 
+        qx.tool.compiler.Console.getInstance().setMachineReadable(true);
       } else if (this.argv["feedback"]) {
         this.__gauge = new Gauge();
         this.__gauge.show("Compiling", 0);
         const TYPES = {
           "error": "ERROR",
-          "warning": "Warning"  
+          "warning": "Warning"
         };
-        qx.tool.compiler.Console.getInstance().setWriter((str, msgId) => { 
+        qx.tool.compiler.Console.getInstance().setWriter((str, msgId) => {
           msgId = qx.tool.compiler.Console.MESSAGE_IDS[msgId];
           if (msgId.type !== "message") {
-            console.log("\n" + TYPES[msgId.type] + ": " + str); 
+            console.log("\n" + TYPES[msgId.type] + ": " + str);
           } else {
             this.__gauge.show(str);
-          } 
+          }
         });
       }
 
       var config = this.__config = await this.parse(this.argv);
       if (!config) {
-        throw new qx.tool.cli.Utils.UserError("Error: Cannot find any configuration"); 
+        throw new qx.tool.cli.Utils.UserError("Error: Cannot find any configuration");
       }
       var maker = this.__maker = await this.createMakerFromConfig(config);
       if (!maker) {
-        throw new qx.tool.cli.Utils.UserError("Error: Cannot find anything to make"); 
+        throw new qx.tool.cli.Utils.UserError("Error: Cannot find anything to make");
       }
-      
+
       let errors = await this.__checkDependencies(maker, config.contribs);
       if (errors.length > 0) {
         if (this.argv.warnAsError) {
@@ -282,12 +282,12 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           console.log(errors.join("\n"));
         }
       }
-      
+
       if (this.argv["clean"]) {
-        await maker.eraseOutputDir(); 
+        await maker.eraseOutputDir();
         await qx.tool.compiler.files.Utils.safeUnlink(maker.getAnalyser().getDbFilename());
         await qx.tool.compiler.files.Utils.safeUnlink(maker.getAnalyser().getResDbFilename());
-      }  
+      }
       var analyser = maker.getAnalyser();
       var target = maker.getTarget();
       if (this.__gauge) {
@@ -305,17 +305,17 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
         }
         if (this.argv.verbose) {
           var startTimes = {};
-          analyser.addListener("compilingClass", evt => { 
+          analyser.addListener("compilingClass", evt => {
             var classname = evt.getData().classFile.getClassName();
             startTimes[classname] = new Date();
             qx.tool.compiler.Console.print("qx.tool.cli.compile.compilingClass", classname);
           });
-          analyser.addListener("compiledClass", evt => { 
+          analyser.addListener("compiledClass", evt => {
             var classname = evt.getData().classFile.getClassName();
             var startTime = startTimes[classname];
             var endTime = new Date();
             var diff = endTime.getTime() - startTime.getTime();
-            qx.tool.compiler.Console.print("qx.tool.cli.compile.compiledClass", classname, qx.tool.cli.Utils.formatTime(diff)); 
+            qx.tool.compiler.Console.print("qx.tool.cli.compile.compiledClass", classname, qx.tool.cli.Utils.formatTime(diff));
           });
         }
       }
@@ -335,10 +335,10 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       analyser.addListener("compiledClass", e => this.dispatchEvent(e.clone()));
       analyser.addListener("saveDatabase", e => this.dispatchEvent(e.clone()));
       target.addListener("checkEnvironment", e => this.dispatchEvent(e.clone()));
-      
+
       var p = qx.tool.compiler.files.Utils.safeStat("source/index.html")
         .then(stat => stat && qx.tool.compiler.Console.print("qx.tool.cli.compile.legacyFiles", "source/index.html"));
-      
+
       // Simple one of make
       if (!this.argv.watch) {
         return p.then(() => {
@@ -347,12 +347,12 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           return maker.make()
             .then(() => {
               if (this.__gauge) {
-                this.__gauge.show("Compiling", 1); 
+                this.__gauge.show("Compiling", 1);
               }
             });
         });
       }
-      
+
       // Continuous make
       let watch = new qx.tool.cli.Watch(maker);
       watch.addListener("making", e => this.dispatchEvent(e.clone()));
@@ -360,7 +360,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       watch.addListener("made", e => this.dispatchEvent(e.clone()));
       return p.then(() => watch.start());
     },
-    
+
 
     /**
      * Processes the configuration from a JSON data structure and creates a Maker
@@ -371,26 +371,26 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
     createMakerFromConfig: async function(data) {
       var t = this;
       var maker = null;
-      
+
       var outputPath = data.target.outputPath;
       if (!outputPath) {
         throw new qx.tool.cli.Utils.UserError("Missing output-path for target " + data.target.type);
       }
-      
+
       maker = new qx.tool.compiler.makers.AppMaker();
       if (!this.argv["erase"]) {
         maker.setNoErase(true);
       }
-      
+
       if (!data.target) {
-        throw new qx.tool.cli.Utils.UserError("No target specified"); 
+        throw new qx.tool.cli.Utils.UserError("No target specified");
       }
       var targetClass = data.target.targetClass ? this.resolveTargetClass(data.target.targetClass): null;
       if (!targetClass && data.target.type) {
         targetClass = this.resolveTargetClass(data.target.type);
       }
       if (!targetClass) {
-        throw new qx.tool.cli.Utils.UserError("Cannot find target class: " + (data.target.targetClass||data.target.type)); 
+        throw new qx.tool.cli.Utils.UserError("Cannot find target class: " + (data.target.targetClass||data.target.type));
       }
       /* eslint-disable new-cap */
       var target = new targetClass(outputPath);
@@ -399,7 +399,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
         qx.tool.compiler.Console.print("qx.tool.cli.compile.deprecatedUri", "target.uri", data.target.uri);
       }
       if (data.target.writeCompileInfo) {
-        target.setWriteCompileInfo(true); 
+        target.setWriteCompileInfo(true);
       }
       target.setWriteLibraryInfo(this.argv.writeLibraryInfo);
       maker.setTarget(target);
@@ -408,26 +408,30 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       if (data.writeAllTranslations) {
         maker.setWriteAllTranslations(data.writeAllTranslations);
       }
-      
+
       if (typeof data.target.typescript == "string") {
         maker.set({ outputTypescript: true, outputTypescriptTo: data.target.typescript });
       } else if (typeof data.target.typescript == "boolean") {
         maker.set({ outputTypescript: true });
-      }  
-      if (this.argv["typescript"]) {
-        maker.set({ outputTypescript: true }); 
       }
-      
-      if (data.environment)
+      if (this.argv["typescript"]) {
+        maker.set({ outputTypescript: true });
+      }
+
+      if (data.environment) {
         maker.setEnvironment(data.environment);
-      
+      }
+      if (data.target.environment) {
+        target.setEnvironment(data.target.environment);
+      }
+
       if (data["path-mappings"]) {
         for (var from in data["path-mappings"]) {
           var to = data["path-mappings"][from];
           target.addPathMapping(from, to);
         }
       }
-      
+
       function mergeArray(dest, ...srcs) {
         srcs.forEach(function(src) {
           if (src) {
@@ -443,14 +447,14 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
 
       var addCreatedAt = data.target["addCreatedAt"] || t.argv["addCreatedAt"];
       if (addCreatedAt) {
-        maker.getAnalyser().setAddCreatedAt(true); 
+        maker.getAnalyser().setAddCreatedAt(true);
       }
 
       var appNames = null;
       if (t.argv["app-name"]) {
-        appNames = t.argv["app-name"].split(","); 
+        appNames = t.argv["app-name"].split(",");
       }
-      
+
       let hasExplicitDefaultApp = false;
       let defaultApp = null;
       data.applications.forEach(function(appData, appIndex) {
@@ -472,7 +476,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           } else if (appData["default"] !== undefined) {
             setDefault = appData["default"];
           }
-          
+
           if (setDefault !== undefined) {
             if (setDefault) {
               if (hasExplicitDefaultApp) {
@@ -489,23 +493,23 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           qx.tool.compiler.Console.print("qx.tool.cli.compile.deprecatedUri", "application.uri", appData.uri);
         }
         if (appData.title) {
-          app.setTitle(appData.title); 
+          app.setTitle(appData.title);
         }
-        
+
         // Take the command line for `minify` as most precedent only if provided
         var minify;
         if ((process.argv.indexOf("--minify") > -1)) {
-          minify = t.argv["minify"]; 
+          minify = t.argv["minify"];
         }
         minify = minify || appData["minify"] || data.target["minify"] || t.argv["minify"];
         if (typeof minify == "boolean") {
-          minify = minify ? "minify" : "off"; 
+          minify = minify ? "minify" : "off";
         }
         if (!minify) {
           minify = "mangle";
         }
         if (typeof target.setMinify == "function") {
-          target.setMinify(minify); 
+          target.setMinify(minify);
         }
         var saveUnminified = appData["save-unminified"] || data.target["save-unminified"] || t.argv["save-unminified"];
         if (typeof saveUnminified == "boolean" && typeof target.setSaveUnminified == "function") {
@@ -528,7 +532,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
             app.addPart(part);
           }
         }
-        
+
         if (target.getType() == "source") {
           var bundle = appData.bundle || data.target.bundle || data.bundle;
           if (bundle) {
@@ -540,14 +544,14 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
             }
           }
         }
-        
+
         app.set({
           exclude: mergeArray([], data.exclude, data.target.exclude, appData.exclude),
           include: mergeArray([], data.include, data.target.include, appData.include)
         });
         maker.addApplication(app);
       });
-      
+
       if (defaultApp) {
         defaultApp.setWriteIndexHtmlToRoot(true);
       } else {
@@ -567,12 +571,12 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
 
       if (!data.libraries.every(libData => fs.existsSync(libData + "/Manifest.json"))) {
         console.log("one or more libraries not found - try to install them through contrib");
-        await (new qx.tool.cli.commands.contrib.Install({quiet:true})).process();        
+        await (new qx.tool.cli.commands.contrib.Install({quiet:true})).process();
       }
-      
+
       const addLibraryAsync = qx.tool.compiler.utils.Promisify.promisify(maker.addLibrary, maker);
       await qx.Promise.all(data.libraries.map(libData => addLibraryAsync(libData)));
-      
+
       // Search for Qooxdoo library if not already provided
       var qxLib = maker.getAnalyser().findLibrary("qx");
       if (!qxLib) {
@@ -592,12 +596,14 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       // check all requieres
       libs.forEach(lib => {
         let requires = lib.getRequires();
-        // check for qooxdoo-range  
+        // check for qooxdoo-range
         let range = lib.getLibraryInfo()["qooxdoo-range"];
         if (range) {
-          console.warn(`${lib.getNamespace()}: The configuration setting qooxdoo-range in Manifest.json is deprecated (see qooxdoo-sdk)`);
+          if (this.argv.verbose) {
+            console.warn(`${lib.getNamespace()}: The configuration setting "qooxdoo-range" in Manifest.json has been deprecated in favor of "requires.qooxdoo-sdk")`);
+          }
           if (!requires) {
-            requires = {};  
+            requires = {};
           }
           if (!requires["qooxdoo-sdk"]) {
             requires["qooxdoo-sdk"] = range;
@@ -630,11 +636,11 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
                   errors.push(`${lib.getNamespace()}: Needs ${req} version ${libVer}, found ${qxVer}`);
                 }
               }
-                break;  
-            }   
-          }  
-        }  
-      });  
+                break;
+            }
+          }
+        }
+      });
       return errors;
     },
 
@@ -649,30 +655,30 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
         return null;
       }
       if (type.$$type == "Class") {
-        return type; 
+        return type;
       }
       if (type == "build") {
-        return qx.tool.compiler.targets.BuildTarget; 
+        return qx.tool.compiler.targets.BuildTarget;
       }
       if (type == "source") {
-        return qx.tool.compiler.targets.SourceTarget; 
+        return qx.tool.compiler.targets.SourceTarget;
       }
       if (type == "typescript") {
-        throw new qx.tool.cli.Utils.UserError("Typescript targets are no longer supported - please use `typescript: true` in source target instead"); 
+        throw new qx.tool.cli.Utils.UserError("Typescript targets are no longer supported - please use `typescript: true` in source target instead");
       }
       if (type) {
         var targetClass;
         if (type.indexOf(".") < 0) {
-          targetClass = qx.Class.getByName("qx.tool.compiler.targets." + type); 
+          targetClass = qx.Class.getByName("qx.tool.compiler.targets." + type);
         } else {
-          targetClass = qx.Class.getByName(type); 
+          targetClass = qx.Class.getByName(type);
         }
         return targetClass;
       }
       return null;
     }
   },
-  
+
   defer: function(statics) {
     qx.tool.compiler.Console.addMessageIds({
       "qx.tool.cli.compile.writingApplication": "Writing application %1",

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -167,9 +167,13 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
         });
       }
       
-      if (this.argv.listenPort) {
-        config.serve.listenPort = this.argv.listenPort; 
+      if (!config.serve) {
+        config.serve = {};
       }
+      if (this.isExplicitArg("listen-port"))
+        config.serve.listenPort = this.argv.listenPort;
+      else
+        config.serve.listenPort = config.serve.listenPort||this.argv.listenPort;
     },
 
     /**

--- a/lib/qx/tool/cli/commands/Serve.js
+++ b/lib/qx/tool/cli/commands/Serve.js
@@ -20,6 +20,7 @@ require("qooxdoo");
 const path = require("upath");
 const process = require("process");
 const express = require("express");
+const http = require("http");
 
 require("app-module-path").addPath(process.cwd() + "/node_modules");
 
@@ -171,26 +172,26 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
           res.send(JSON.stringify(obj, null, 2));
         });
       }
-      this.addListenerOnce("made", e =>
-        app.listen(config.serve.listenPort, () => qx.tool.compiler.Console.print("qx.tool.cli.serve.webStarted", "http://localhost:" + config.serve.listenPort)));
-    },
-
-    /*
-     * @Override
-     */
-    _mergeArguments: function(parsedArgs, config, contribConfig) {
-      if (!config.serve) {
-        config.serve = {};
-      }
-      this.base(arguments, parsedArgs, config, contribConfig);       
-      config.serve.listenPort = config.serve.listenPort||this.argv.listenPort;
-      return config;
+      this.addListenerOnce("made", e => {
+        let server = http.createServer(app);
+        server.on("error", e => {
+          if (e.code == "EADDRINUSE") {
+            qx.tool.compiler.Console.print("qx.tool.cli.serve.webAddrInUse", config.serve.listenPort);
+            process.exit(-1);
+          } else {
+            console.log("Error when starting web server: " + e);
+          }
+        });
+        server.listen(config.serve.listenPort, () => 
+          qx.tool.compiler.Console.print("qx.tool.cli.serve.webStarted", "http://localhost:" + config.serve.listenPort));
+      });
     }
   },
 
   defer: function(statics) {
     qx.tool.compiler.Console.addMessageIds({
-      "qx.tool.cli.serve.webStarted": "Web server started, please browse to %1"
+      "qx.tool.cli.serve.webStarted": "Web server started, please browse to %1",
+      "qx.tool.cli.serve.webAddrInUse": "Web server cannot start because port %1 is already in use"
     });
   }
 });

--- a/test/test-deps.js
+++ b/test/test-deps.js
@@ -18,7 +18,9 @@ async function createMaker() {
       writeCompileInfo: true,
       environment: {
         envVar1: "ONE",
-        envVar2: "TWO"
+        envVar2: "TWO",
+        "test.overridden4": "target",
+        "test.overridden5": "target"
       }
     }),
     locales: ["en"],
@@ -31,7 +33,12 @@ async function createMaker() {
       "test.isFalse": false,
       "test.isTrue": true,
       "test.someValue": "some",
-      "test.appValue": false
+      "test.appValue": false,
+      "test.overridden1": false,
+      "test.overridden2": true,
+      "test.overridden3": "global",
+      "test.overridden4": "global",
+      "test.overridden5": "global"
     }
   });
   maker.addApplication(new qx.tool.compiler.app.Application("testapp.Application").set({
@@ -41,7 +48,10 @@ async function createMaker() {
       envVar2: "222",
       envVar3: "333",
       "test.appValue": true,
-      "qx.promise": true
+      "qx.promise": true,
+      "test.overridden1": true,
+      "test.overridden2": false,
+      "test.overridden5": "application"
     }
   }));
 
@@ -170,8 +180,9 @@ test('Checks dependencies and environment settings', (assert) => {
               assert.ok(src.match(/var envVar2 = qx.core.Environment.get\("envVar2"\)/), "environment setting for envVar2");
               assert.ok(src.match(/var envVar3 = qx.core.Environment.get\("envVar3"\)/), "environment setting for envVar3");
               assert.ok(src.match(/var envVar4 = "four"/), "environment setting for envVar4");
-              assert.ok(src.match(/var envVarSelect1 = 1/), "environment setting for envVarSelect1");
-              assert.ok(src.match(/var envVarSelect2 = 1/), "environment setting for envVarSelect2");
+              assert.ok(src.match(/var envTestOverriden3 = "global"/), "environment setting for envTestOverriden3");
+              assert.ok(src.match(/var envTestOverriden4 = "target"/), "environment setting for envTestOverriden4");
+              assert.ok(src.match(/var envTestOverriden5 = qx.core.Environment.get\("test.overridden5"\)/), "environment setting for envTestOverriden5");
               assert.ok(src.match(/var envVarSelect3 = 0/), "environment setting for envVarSelect3");
               assert.ok(src.match(/var envVarDefault1 = "some"/), "environment setting for envVarDefault1");
               assert.ok(src.match(/var envVarDefault2 = qx.core.Environment.get("test.noValue") || "default2"/), "environment setting for envVarDefault2");

--- a/test/testapp/compile.json
+++ b/test/testapp/compile.json
@@ -2,7 +2,11 @@
 	"targets": [
 		{
 			"type": "source",
-			"outputPath": "compiled/source"
+			"outputPath": "compiled/source",
+			"environment": {
+                "test.overridden4": "target",
+                "test.overridden5": "target"
+			}
 		},
 		{
 			"type": "build",
@@ -21,7 +25,8 @@
 			"name": "testapp",
 			"environment": {
                 "test.overridden1": true,
-                "test.overridden2": false
+                "test.overridden2": false,
+                "test.overridden5": "application"
 			}
 		}
 	],
@@ -31,7 +36,10 @@
 		"test.isTrue": true,
 		"test.someValue": "some",
         "test.overridden1": false,
-        "test.overridden2": true
+        "test.overridden2": true,
+        "test.overridden3": "global",
+        "test.overridden4": "global",
+        "test.overridden5": "global"
 	},
 
     "bundle": {
@@ -55,5 +63,9 @@
         "pluginTwo": {
             "include": [ "testapp.plugins.PluginTwo", "testapp.plugins.Two*" ]
         }
+	},
+	
+	"serve": {
+	   "listenPort": 9082
 	}
 }

--- a/test/testapp/source/class/testapp/Application.js
+++ b/test/testapp/source/class/testapp/Application.js
@@ -111,6 +111,9 @@ qx.Class.define("testapp.Application", {
       var envVar2 = qx.core.Environment.get("envVar2");
       var envVar3 = qx.core.Environment.get("envVar3");
       var envVar4 = qx.core.Environment.get("envVar4");
+      var envTestOverriden3 = qx.core.Environment.get("test.overridden3");
+      var envTestOverriden4 = qx.core.Environment.get("test.overridden4");
+      var envTestOverriden5 = qx.core.Environment.get("test.overridden5");
       var envVarSelect1 = qx.core.Environment.select("test.someValue", {
         "none": 0,
         "some": 1,


### PR DESCRIPTION
fixes regression where target environment vars are ignored;
adds unit tests for regression;
fixes issue where command line `--listen-port` is ignored for `qx serve`;
better message when qx serve port is in use already