### PR TITLE
Updates to bootPath templating

### DIFF
--- a/docs/compiler/CustomAppStartup.md
+++ b/docs/compiler/CustomAppStartup.md
@@ -36,9 +36,36 @@ If you want to customise this further, you can replace the `index.html` with you
 
 # Custom index.html for your applications
 
-To customise the index.html which is generated, create a file called `boot/index.html` that will be used as a template.  The `boot/index.html` is copied with template variables in form `${variableName}` replaced and with the application's `boot.js` script inserted before the close `</body>` - you can add whatever scripts you like, but do not try to link to the `boot.js`.
+To customise the index.html which is generated, create a file called `boot/index.html` that will be used as a template.  The `boot/index.html` is copied with template variables in form `${variableName}` replaced.  
 
-The template variables supported are `resourcePath` (which is a relative path to the `resource` output folder) and `targetPath` (which is a relative path to the target output folder). 
+The template variables supported are:
+* `resourcePath` - a relative path to the `resource` output folder 
+* `targetPath` -  a relative path to the target output folder
+* `appTitle` - the application title, as configured in `compile.json`
+* `appPath` - a relative path to the application's output folder
+* `preBootJs` - a code snippet to be placed in index.html immediately before the boot.js script is loaded
+
+Note that previous version of the compiler would also add a `<script>` tag which links to `boot.js` but this is now also done by template replacements - you MUST include this code (or it's equivalent) in your index.html:
+
+```
+${preBootJs}
+<script type="text/javascript" src="${appPath}boot.js"></script>
+```
+
+Here's a complete, although minimal, example of an index.html:
+```
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>${appTitle}</title>
+</head>
+<body>
+  ${preBootJs}
+  <script type="text/javascript" src="${appPath}boot.js"></script>
+</body>
+</html>
+``` 
 
 
 # Splash Screens

--- a/lib/qx/tool/compiler/Console.js
+++ b/lib/qx/tool/compiler/Console.js
@@ -98,8 +98,6 @@ qx.Class.define("qx.tool.compiler.Console", {
       "qx.tool.compiler.compiler.missingClassDef": "Missing class definition - no call to qx.Class.define (or qx.Mixin.define etc)",
       "qx.tool.compiler.compiler.syntaxError": "Syntax error: %1\n%2",
       "qx.tool.compiler.compiler.wrongClassName": "Wrong class name or filename - the filename does not match any classes defined",
-      "qx.tool.compiler.defer.unsafe": "Unsafe use of 'defer' method to access external class: %1",
-      "qx.tool.compiler.symbol.unresolved": "Unresolved use of symbol %1",
       
       // Application errors & warnings (@see {Application})
       "qx.tool.compiler.application.partRecursive": "Part %1 has recursive dependencies on other parts",
@@ -123,7 +121,13 @@ qx.Class.define("qx.tool.compiler.Console", {
     statics.addMessageIds({
       "qx.tool.compiler.translate.invalidMessageId": "Cannot interpret message ID %1",
       "qx.tool.compiler.translate.invalidMessageIds": "Cannot interpret message ID %1, %2",
-      "qx.tool.compiler.translate.invalidMessageIds3": "Cannot interpret message ID %1, %2, %3"
+      "qx.tool.compiler.translate.invalidMessageIds3": "Cannot interpret message ID %1, %2, %3",
+      
+      "qx.tool.compiler.defer.unsafe": "Unsafe use of 'defer' method to access external class: %1",
+      "qx.tool.compiler.symbol.unresolved": "Unresolved use of symbol %1",
+      
+      "qx.tool.compiler.target.missingBootJs": "There is no reference to boot.js script in the index.html copied from %1 (see https://git.io/fh7NI)", 
+      "qx.tool.compiler.target.missingPreBootJs": "There is no reference to ${preBootJs} in the index.html copied from %1 (see https://git.io/fh7NI)", 
     }, "warning");
   },
   

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -852,87 +852,86 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
 
       var resDir = this.getApplicationRoot(application);
 
-      let writeIndexHtml = async (appRootDir, writingIndexToRoot) => {
-        let appRoot = "";
-        let preBootJs = "";
-        if (writingIndexToRoot) {
-          appRoot = t.getProjectDir(application) + "/";
-          preBootJs = "  <script type=\"text/javascript\">\n" +
-            "    if (!window.qx)\n" +
-            "      window.qx = {};\n" +
-            "    qx.$$$appRoot = \"" + appRoot + "\";\n" +
-            "  </script>\n";
+      let pathToTarget = path.relative(path.join(t.getOutputDir(), t.getProjectDir(application)), t.getOutputDir()) + "/";
+      let TEMPLATE_VARS = {
+          "resourcePath": pathToTarget + "resource/",
+          "targetPath": pathToTarget,
+          "appPath": "",
+          "preBootJs": "",
+          "appTitle": (application.getTitle()||"Qooxdoo Application")
+      };
+      
+      function replaceVars(code) {
+        for (let varName in TEMPLATE_VARS) {
+          code = code.replace(new RegExp(`\\$\{${varName}\}`, "g"), TEMPLATE_VARS[varName]);
         }
+        return code;
+      }
+      
+      let defaultIndexHtml = replaceVars(
+          "<!DOCTYPE html>\n" +
+          "<html>\n" +
+          "<head>\n" +
+          "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />\n" +
+          "  <title>${appTitle}</title>\n" +
+          "</head>\n" +
+          "<body>\n" +
+          "  <!-- This index.html can be customised by creating a boot/index.html (do not include Qooxdoo application script tags like\n" +
+          "       the one below because they will be added automatically)\n" +
+          "    -->\n" +
+          "${preBootJs}\n" +
+          "  <script type=\"text/javascript\" src=\"${appPath}boot.js\"></script>\n" +
+          "</body>\n" +
+          "</html>\n");
 
-        let pathToTarget = writingIndexToRoot ? "" : path.relative(path.join(t.getOutputDir(), t.getProjectDir(application)), t.getOutputDir()) + "/";
-        const TEMPLATE_VARS = {
-            "resourcePath": pathToTarget + "resource/",
-            "targetPath": pathToTarget,
-            "appPath": appRoot + t.getScriptPrefix(),
-            "preBootJs": preBootJs,
+      var bootDir = application.getBootPath();
+      var stats = bootDir && (await qx.tool.compiler.files.Utils.safeStat(bootDir));
+      let indexHtml = null;
+      if (stats && stats.isDirectory()) {
+        await qx.tool.compiler.files.Utils.sync(bootDir, resDir, (from, to) => {
+          if (!from.endsWith(".html")) {
+            return true;
+          }
+          return fs.readFileAsync(from, "utf8")
+            .then(data => {
+              if (path.basename(from) == "index.html") {
+                if (!data.match(/\$\{\s*preBootJs\s*\}/)) {
+                  data = data.replace("</body>", "\n${preBootJs}\n</body>");
+                  qx.tool.compiler.Console.print("qx.tool.compiler.target.missingPreBootJs", from);
+                }
+                if (!data.match(/script.*boot.js/)) {
+                  data = data.replace("</body>", "\n  <script type=\"text/javascript\" src=\"${appPath}boot.js\"></script>\n</body>");
+                  qx.tool.compiler.Console.print("qx.tool.compiler.target.missingBootJs", from);
+                }
+                indexHtml = data;
+              }
+              data = replaceVars(data);
+              return fs.writeFileAsync(to, data, "utf8")
+                .then(() => false);
+            });
+        });
+      }
+      if (!indexHtml) {
+        indexHtml = defaultIndexHtml;
+        await fs.writeFileAsync(resDir + "index.html", replaceVars(indexHtml), { encoding: "utf8" });
+      }
+      
+      if (application.getWriteIndexHtmlToRoot()) {
+        pathToTarget = "";
+        TEMPLATE_VARS = {
+            "resourcePath": "resource/",
+            "targetPath": "",
+            "appPath": t.getProjectDir(application) + "/",
+            "preBootJs": 
+              "  <script type=\"text/javascript\">\n" +
+              "    if (!window.qx)\n" +
+              "      window.qx = {};\n" +
+              "    qx.$$$appRoot = \"" + t.getProjectDir(application) + "\";\n" +
+              "  </script>\n",
             "appTitle": (application.getTitle()||"Qooxdoo Application")
         };
-        
-        function replaceVars(code) {
-          for (let varName in TEMPLATE_VARS) {
-            code = code.replace(new RegExp(`\\$\{${varName}\}`, "g"), TEMPLATE_VARS[varName]);
-          }
-          return code;
-        }
-        
-        let defaultIndexHtml = replaceVars(
-            "<!DOCTYPE html>\n" +
-            "<html>\n" +
-            "<head>\n" +
-            "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />\n" +
-            "  <title>${appTitle}</title>\n" +
-            "</head>\n" +
-            "<body>\n" +
-            "  <!-- This index.html can be customised by creating a boot/index.html (do not include Qooxdoo application script tags like\n" +
-            "       the one below because they will be added automatically)\n" +
-            "    -->\n" +
-            "${preBootJs}\n" +
-            "  <script type=\"text/javascript\" src=\"${appPath}boot.js\"></script>\n" +
-            "</body>\n" +
-            "</html>\n");
-
-        var classname = application.getClassName();
-        var bootDir = application.getBootPath();
-        var stats = bootDir && (await qx.tool.compiler.files.Utils.safeStat(bootDir));
-        let writeIndexHtml = true;
-        if (stats && stats.isDirectory()) {
-          await qx.tool.compiler.files.Utils.sync(bootDir, resDir, (from, to) => {
-            if (!from.endsWith(".html")) {
-              return true;
-            }
-            return fs.readFileAsync(from, "utf8")
-              .then(data => {
-                if (path.basename(from) == "index.html") {
-                  writeIndexHtml = false;
-                  if (!data.match(/\$\{\s*preBootJs\s*\}/)) {
-                    data = data.replace("</body>", "\n${preBootJs}\n</body>");
-                    qx.tool.compiler.Console.print("qx.tool.compiler.target.missingPreBootJs", from);
-                  }
-                  if (!data.match(/script.*boot.js/)) {
-                    data = data.replace("</body>", "\n  <script type=\"text/javascript\" src=\"${appPath}boot.js\"></script>\n</body>");
-                    qx.tool.compiler.Console.print("qx.tool.compiler.target.missingBootJs", from);
-                  }
-                }
-                data = replaceVars(data);
-                return fs.writeFileAsync(to, data, "utf8")
-                  .then(() => false);
-              });
-          });
-        }
-        if (writeIndexHtml) {
-          await writeFile(appRootDir + t.getScriptPrefix() + "index.html", defaultIndexHtml, { encoding: "utf8" });
-        }
-      };
-
-      if (application.getWriteIndexHtmlToRoot()) {
-        await writeIndexHtml(t.getOutputDir(), true);
+        await fs.writeFileAsync(t.getOutputDir() + "index.html", replaceVars(indexHtml), { encoding: "utf8" });
       }
-      await writeIndexHtml(t.getApplicationRoot(application), false);
     },
 
     /**

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -854,62 +854,79 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
 
       let writeIndexHtml = async (appRootDir, writingIndexToRoot) => {
         let appRoot = "";
-        let bootJs = "";
+        let preBootJs = "";
         if (writingIndexToRoot) {
           appRoot = t.getProjectDir(application) + "/";
-          bootJs = "  <script type=\"text/javascript\">\n" +
+          preBootJs = "  <script type=\"text/javascript\">\n" +
             "    if (!window.qx)\n" +
             "      window.qx = {};\n" +
             "    qx.$$$appRoot = \"" + appRoot + "\";\n" +
             "  </script>\n";
         }
-        bootJs += "  <script type=\"text/javascript\" src=\"" + appRoot + t.getScriptPrefix() + "boot.js\"></script>\n";
 
-        let defaultIndexHtml =
+        let pathToTarget = writingIndexToRoot ? "" : path.relative(path.join(t.getOutputDir(), t.getProjectDir(application)), t.getOutputDir()) + "/";
+        const TEMPLATE_VARS = {
+            "resourcePath": pathToTarget + "resource/",
+            "targetPath": pathToTarget,
+            "appPath": appRoot + t.getScriptPrefix(),
+            "preBootJs": preBootJs,
+            "appTitle": (application.getTitle()||"Qooxdoo Application")
+        };
+        
+        function replaceVars(code) {
+          for (let varName in TEMPLATE_VARS) {
+            code = code.replace(new RegExp(`\\$\{${varName}\}`, "g"), TEMPLATE_VARS[varName]);
+          }
+          return code;
+        }
+        
+        let defaultIndexHtml = replaceVars(
             "<!DOCTYPE html>\n" +
             "<html>\n" +
             "<head>\n" +
             "  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />\n" +
-            "  <title>" + (application.getTitle()||"Qooxdoo Application") + "</title>\n" +
+            "  <title>${appTitle}</title>\n" +
             "</head>\n" +
             "<body>\n" +
             "  <!-- This index.html can be customised by creating a boot/index.html (do not include Qooxdoo application script tags like\n" +
             "       the one below because they will be added automatically)\n" +
             "    -->\n" +
+            "${preBootJs}\n" +
+            "  <script type=\"text/javascript\" src=\"${appPath}boot.js\"></script>\n" +
             "</body>\n" +
-            "</html>\n";
+            "</html>\n");
 
         var classname = application.getClassName();
         var bootDir = application.getBootPath();
         var stats = bootDir && (await qx.tool.compiler.files.Utils.safeStat(bootDir));
-        let html;
-        if (!stats || !stats.isDirectory()) {
-          html = defaultIndexHtml;
-        } else {
-          let pathToTarget = writingIndexToRoot ? "" : path.relative(path.join(t.getOutputDir(), t.getProjectDir(application)), t.getOutputDir()) + "/";
-          const TEMPLATE_VARS = {
-              "resourcePath": pathToTarget + "resource/",
-              "targetPath": pathToTarget
-          };
+        let writeIndexHtml = true;
+        if (stats && stats.isDirectory()) {
           await qx.tool.compiler.files.Utils.sync(bootDir, resDir, (from, to) => {
             if (!from.endsWith(".html")) {
               return true;
             }
             return fs.readFileAsync(from, "utf8")
               .then(data => {
-                for (let varName in TEMPLATE_VARS) {
-                  data = data.replace(new RegExp(`\\$\{${varName}\}`, "g"), TEMPLATE_VARS[varName]);
+                if (path.basename(from) == "index.html") {
+                  writeIndexHtml = false;
+                  if (!data.match(/\$\{\s*preBootJs\s*\}/)) {
+                    data = data.replace("</body>", "\n${preBootJs}\n</body>");
+                    qx.tool.compiler.Console.print("qx.tool.compiler.target.missingPreBootJs", from);
+                  }
+                  if (!data.match(/script.*boot.js/)) {
+                    data = data.replace("</body>", "\n  <script type=\"text/javascript\" src=\"${appPath}boot.js\"></script>\n</body>");
+                    qx.tool.compiler.Console.print("qx.tool.compiler.target.missingBootJs", from);
+                  }
                 }
-                if (path.basename(from) == "index.html")
-                  html = data;
+                data = replaceVars(data);
                 return fs.writeFileAsync(to, data, "utf8")
                   .then(() => false);
               });
           });
         }
-        let str = bootJs + "</body>";
-        let after = html.replace("</body>", str);
-        await writeFile(appRootDir + t.getScriptPrefix() + "index.html", after, { encoding: "utf8" });
+        if (writeIndexHtml) {
+          await writeFile(appRootDir + t.getScriptPrefix() + "index.html", defaultIndexHtml, { encoding: "utf8" });
+        }
       };
 
       if (application.getWriteIndexHtmlToRoot()) {


### PR DESCRIPTION
fixes an edge case when no index.html in bootPath causes an exception;
makes inclusion of boot.js done by templates;
tests for missing templates.

Please check out see https://github.com/qooxdoo/qooxdoo-compiler/blob/ee7307acfc0460871eefd844f145fb8d2600510d/docs/compiler/CustomAppStartup.md#custom-indexhtml-for-your-applications for details of the changes to boot files