### PR TITLE
make the check for boot.js less strict. Here is a use case:

### DIFF
--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -899,7 +899,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
                   data = data.replace("</body>", "\n${preBootJs}\n</body>");
                   qx.tool.compiler.Console.print("qx.tool.compiler.target.missingPreBootJs", from);
                 }
-                if (!data.match(/script.*boot.js/)) {
+                if (!data.match(/\s*boot.js\s*/)) {
                   data = data.replace("</body>", "\n  <script type=\"text/javascript\" src=\"${appPath}boot.js\"></script>\n</body>");
                   qx.tool.compiler.Console.print("qx.tool.compiler.target.missingBootJs", from);
                 }


### PR DESCRIPTION
  <script>
    [
       "settings.qxrpc" + location.search
	 , "${appPath}boot.js"
    ].forEach(function(src) {
	var script = document.createElement('script');
        script.type = "text/javascript";
	script.src = src;
	script.async = false;
	document.head.appendChild(script);
    });
  </script>