### PR TITLE
Don't update package.json due to new qooxdoo-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "test": "cross-os test.os",
-    "install": "npm update qooxdoo-sdk",
+    "install": "npm update --no-save qooxdoo-sdk",
     "compileWebSite": "cd tool/cli/serve && node compile.js",
     "lint": "eslint lib"
   },


### PR DESCRIPTION
When checking out qxcompiler from git, running `npm install` should not change any committed files. This prevents the embedded `npm update qooxdoo-sdk` from changing the `package.json` file.