### PR TITLE
Fix message shown when a library is not found.

### DIFF
--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -570,7 +570,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       });
 
       if (!data.libraries.every(libData => fs.existsSync(libData + "/Manifest.json"))) {
-        console.log("one or more libraries not found - try to install them through contrib");
+        console.log("One or more libraries not found - trying to install them from library repository...");
         await (new qx.tool.cli.commands.contrib.Install({quiet:true})).process();
       }
 


### PR DESCRIPTION
The current message is ambigous, might be understood to mean that the user should "try to install..."
Also removing reference to "contrib" in preparation of #279.