### PR TITLE
boot.js should not use urls with //

### DIFF
--- a/lib/qx/tool/compiler/app/loader-browser.tmpl.js
+++ b/lib/qx/tool/compiler/app/loader-browser.tmpl.js
@@ -1,6 +1,6 @@
 (function(){
 
-if (!window.qx) 
+if (!window.qx)
   window.qx = {};
 
 qx.$$start = new Date();
@@ -18,7 +18,7 @@ if (!qx.$$appRoot) {
       }
     }
   }
-  
+
   if (bootScriptElement) {
     strBase = bootScriptElement.src;
     pos = strBase.indexOf('?');
@@ -51,18 +51,18 @@ if (!qx.$$appRoot) {
   if (qx.$$appRoot[qx.$$appRoot.length - 1] != "/")
     qx.$$appRoot += "/";
 }
-  
-if (!qx.$$environment) 
+
+if (!qx.$$environment)
   qx.$$environment = {};
 
 var envinfo = %{EnvSettings};
-for (var k in envinfo) 
+for (var k in envinfo)
   qx.$$environment[k] = envinfo[k];
 
-if (!qx.$$libraries) 
+if (!qx.$$libraries)
   qx.$$libraries = {};
 var libinfo = %{Libinfo};
-for (var k in libinfo) 
+for (var k in libinfo)
   qx.$$libraries[k] = libinfo[k];
 
 qx.$$resources = %{Resources};
@@ -114,7 +114,7 @@ qx.$$loader = {
       var euri;
       if (uri.length == 2 && uri[0] in libs) {
         var prefix = libs[uri[0]][pathName];
-        euri = prefix + "/" + uri[1];
+        euri = prefix + uri[1];
       } else {
         euri = compressedUris[i];
       }
@@ -126,9 +126,9 @@ qx.$$loader = {
     }
     return uris;
   },
-  
+
   deferredEvents: null,
-  
+
   /*
    * Adds event handlers
    */
@@ -140,7 +140,7 @@ qx.$$loader = {
       handlers = this.deferredEvents[eventType] = [];
     handlers.push({ eventType: eventType, handler: handler });
   },
-  
+
   /*
    * Startup handler, hooks into Qooxdoo proper
    */
@@ -189,7 +189,7 @@ qx.$$loader = {
       var add = l.decodeUris(l.packages[l.parts[l.boot][0]].uris);
       Array.prototype.push.apply(allScripts, add);
     }
-    
+
     function begin() {
       flushScriptQueue(function(){
         // Opera needs this extra time to parse the scripts
@@ -200,7 +200,7 @@ qx.$$loader = {
         }, 0);
       });
     }
-    
+
     if (qx.$$loader.splashscreen)
       qx.$$loader.splashscreen.loadBegin(begin);
     else
@@ -238,7 +238,7 @@ if (qx.$$loader.splashscreen) {
   if (typeof settings.isLoadChunked == "boolean")
     qx.$$loader.isLoadChunked = settings.isLoadChunked;
   if (typeof settings.loadChunkSize == "number" && settings.loadChunkSize > 1)
-    qx.$$loader.loadChunkSize = settings.loadChunkSize; 
+    qx.$$loader.loadChunkSize = settings.loadChunkSize;
 }
 
 /*
@@ -250,11 +250,11 @@ for (var key in URL_PARAMETERS) {
   case "add-no-cache":
     qx.$$loader.addNoCacheParam = value === true;
     break;
-    
+
   case "load-parallel":
     qx.$$loader.isLoadParallel = value === true;
     break;
-    
+
   case "load-chunked":
     qx.$$loader.isLoadChunked = value === true;
     break;
@@ -317,14 +317,14 @@ function loadCss(uri) {
 qx.$$loader.importPackageData = function (dataMap, callback) {
   if (dataMap["resources"]) {
     var resMap = dataMap["resources"];
-    for (var k in resMap) 
+    for (var k in resMap)
       qx.$$resources[k] = resMap[k];
   }
   if (dataMap["locales"]) {
     var locMap = dataMap["locales"];
     var qxlocs = qx.$$locales;
     for (var lang in locMap) {
-      if (!qxlocs[lang]) 
+      if (!qxlocs[lang])
         qxlocs[lang] = locMap[lang];
       else
         for (var k in locMap[lang]) qxlocs[lang][k] = locMap[lang][k];
@@ -334,10 +334,10 @@ qx.$$loader.importPackageData = function (dataMap, callback) {
     var trMap   = dataMap["translations"];
     var qxtrans = qx.$$translations;
     for (var lang in trMap) {
-      if (!qxtrans[lang]) 
+      if (!qxtrans[lang])
         qxtrans[lang] = trMap[lang];
       else
-        for (var k in trMap[lang]) 
+        for (var k in trMap[lang])
           qxtrans[lang][k] = trMap[lang][k];
     }
   }
@@ -352,7 +352,7 @@ qx.$$loader.importPackageData = function (dataMap, callback) {
 var allScripts = [];
 var nextScriptIndex = 0;
 
-var flushScriptQueue = 
+var flushScriptQueue =
   qx.$$loader.isLoadParallel && qx.$$loader.isLoadChunked ?
     function(callback) {
       if (nextScriptIndex >= allScripts.length)
@@ -419,7 +419,7 @@ var flushScriptQueue =
         loadScript(uri, onLoad);
       }
     }
-    
+
   :
     function(callback) {
       var options = {
@@ -468,4 +468,3 @@ if (document.addEventListener) {
 %{BootPart}
 
 qx.$$loader.init();
-

--- a/lib/qx/tool/compiler/targets/SourceTarget.js
+++ b/lib/qx/tool/compiler/targets/SourceTarget.js
@@ -48,16 +48,16 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.SourceTarget", {
     _writeApplication: async function(compileInfo) {
       var t = this;
       var application = compileInfo.application;
-      
+
       var targetUri = t._getOutputRootUri(application);
       var appRootDir = this.getApplicationRoot(application);
 
 
-      var mapTo = this.getPathMapping(path.join(appRootDir, this.getOutputDir(), "transpiled"));
-      var sourceUri = mapTo ? mapTo : targetUri + "transpiled";
+      var mapTo = this.getPathMapping(path.join(appRootDir, this.getOutputDir(), "transpiled/"));
+      var sourceUri = mapTo ? mapTo : targetUri + "transpiled/";
       mapTo = this.getPathMapping(path.join(appRootDir, this.getOutputDir(), "resource"));
       var resourceUri = mapTo ? mapTo : targetUri + "resource";
-      
+
 
       application.getRequiredLibraries().forEach(ns => {
         compileInfo.configdata.libraries[ns] = {


### PR DESCRIPTION
when boot.js assembles the urls for the components/parts to load it can end up with double-slashes in the url. the built in webserver of qx does not mind, but for example the aoihttp server from python does not like such urls at all .. this patch fixes it.

As @johnspackman mentioned on gitter

> the policy I’ve tried to take is that directories always get ‘/‘ appended in advance, so that “” is valid to prepend to a path

I have not found the code responsible for building FontLoading urls which would end up with double slashes when changing resourceUri too ... maybe @johnspackman can help there.