### PR TITLE
fix boot.js path

### DIFF
--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -629,11 +629,15 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
               }
               default: {
                 let l = libs.find(entry => entry.getRootDir() == contribs[req]);
-                let qxVer = l.getLibraryInfo().version;
-                if (!semver.valid(qxVer, {loose: true})) {
-                  console.warn(`${req}: Version is not valid: ${qxVer}`);
-                } else if (!semver.satisfies(qxVer, libVer, {loose: true})) {
-                  errors.push(`${lib.getNamespace()}: Needs ${req} version ${libVer}, found ${qxVer}`);
+                if (!l) {
+                  errors.push(`${lib.getNamespace()}: Cannot find required library with namespace ${req}`);
+                } else {
+                  let qxVer = l.getLibraryInfo().version;
+                  if (!semver.valid(qxVer, {loose: true})) {
+                    console.warn(`${req}: Version is not valid: ${qxVer}`);
+                  } else if (!semver.satisfies(qxVer, libVer, {loose: true})) {
+                    errors.push(`${lib.getNamespace()}: Needs ${req} version ${libVer}, found ${qxVer}`);
+                  }
                 }
               }
                 break;

--- a/lib/qx/tool/compiler/Analyser.js
+++ b/lib/qx/tool/compiler/Analyser.js
@@ -387,7 +387,7 @@ module.exports = qx.Class.define("qx.tool.compiler.Analyser", {
         function getIndirectLoadDependencies(className) {
           var deps = [];
           var info = t.__db.classInfo[className];
-          if (info.dependsOn) {
+          if (info && info.dependsOn) {
             for (var depName in info.dependsOn) {
               if (info.dependsOn[depName].load) {
                 getConstructDependencies(depName).forEach(function(className) {
@@ -412,6 +412,10 @@ module.exports = qx.Class.define("qx.tool.compiler.Analyser", {
                   for (var depName in deps) {
                     t._addRequiredClass(depName);
                   }
+                }
+                if (err && err.code === "ENOCLASSFILE") {
+                  console.error(err.message);
+                  err = null;
                 }
                 return cb(err);
               });
@@ -899,7 +903,9 @@ module.exports = qx.Class.define("qx.tool.compiler.Analyser", {
 
       var library = t.getLibraryFromClassname(className);
       if (!library) {
-        cb && cb(new Error("Cannot find class file " + className));
+        let err = new Error("Cannot find class file " + className);
+        err.code = "ENOCLASSFILE";
+        cb && cb(err);
         return;
       }
       var sourceClassFilename = qx.tool.compiler.ClassFile.getSourcePath(library, className);

--- a/lib/qx/tool/compiler/Console.js
+++ b/lib/qx/tool/compiler/Console.js
@@ -105,6 +105,7 @@ qx.Class.define("qx.tool.compiler.Console", {
       "qx.tool.compiler.application.noBootPart": "Cannot find a boot part",
       "qx.tool.compiler.application.conflictingExactPart": "Conflicting exact match for %1, could be %2 or %3",
       "qx.tool.compiler.application.conflictingBestPart": "Conflicting best match for %1, could be %2 or %3",
+      "qx.tool.compiler.missingAppLibrary": "Missing application library %1",
       
       "qx.tool.compiler.library.emptyManifest": "Empty Manifest.json in library at %1",
       

--- a/lib/qx/tool/compiler/targets/Target.js
+++ b/lib/qx/tool/compiler/targets/Target.js
@@ -337,6 +337,10 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
       var libraryInfoMap = {};
       var appClassname = application.getClassName();
       var library = compileInfo.library = analyser.getLibraryFromClassname(appClassname);
+      if (!library) {
+        qx.tool.compiler.Console.print("qx.tool.compiler.missingAppLibrary", appClassname);
+        return qx.Promise.resolve();
+      }
       const requiredLibs = application.getRequiredLibraries();
       var namespace = compileInfo.namespace = library.getNamespace();
       if (this.isWriteLibraryInfo()) {
@@ -865,7 +869,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
         return code;
       }
       
-      let defaultIndexHtml = replaceVars(
+      let defaultIndexHtml = 
           "<!DOCTYPE html>\n" +
           "<html>\n" +
           "<head>\n" +
@@ -879,7 +883,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
           "${preBootJs}\n" +
           "  <script type=\"text/javascript\" src=\"${appPath}boot.js\"></script>\n" +
           "</body>\n" +
-          "</html>\n");
+          "</html>\n";
 
       var bootDir = application.getBootPath();
       var stats = bootDir && (await qx.tool.compiler.files.Utils.safeStat(bootDir));


### PR DESCRIPTION
fixes bug where the `<script>` tag in the top level `index.html` has a missing path to boot.js;
fixes bug where missing libraries cause crashes instead of gracefully notifying the user