### PR TITLE
Faster compile with watch & fix slashes

### DIFF
--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -152,6 +152,11 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
             describe: "Write library information to the script, for reflection",
             type: "boolean",
             default: true
+          },
+          "bundling": {
+            describe: "Whether bundling is enabled",
+            type: "boolean",
+            default: true
           }
         },
         handler: function(argv) {
@@ -533,7 +538,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           }
         }
 
-        if (target.getType() == "source") {
+        if (target.getType() == "source" && t.argv.bundling) {
           var bundle = appData.bundle || data.target.bundle || data.bundle;
           if (bundle) {
             if (bundle.include) {

--- a/lib/qx/tool/compiler/app/loader-browser.tmpl.js
+++ b/lib/qx/tool/compiler/app/loader-browser.tmpl.js
@@ -114,6 +114,8 @@ qx.$$loader = {
       var euri;
       if (uri.length == 2 && uri[0] in libs) {
         var prefix = libs[uri[0]][pathName];
+        if (prefix.length && prefix[prefix.length - 1] != '/')
+          prefix += "/";
         euri = prefix + uri[1];
       } else {
         euri = compressedUris[i];

--- a/lib/qx/tool/compiler/makers/AppMaker.js
+++ b/lib/qx/tool/compiler/makers/AppMaker.js
@@ -142,8 +142,20 @@ module.exports = qx.Class.define("qx.tool.compiler.makers.AppMaker", {
         .then(() => {
           var target = this.getTarget();
           this.fireEvent("writingApplications");
+
+          // Detect which applications need to be recompiled by looking for classes recently compiled
+          //  which is on the application's dependency list.  The first time `.make()` is called there
+          //  will be no dependencies so we just compile anyway, but `qx compile --watch` will call it
+          //  multiple times
+          let compiledClasses = this.getRecentlyCompiledClasses(true);
+          var appsThisTime = this.__applications.filter(app => {
+            let loadDeps = app.getDependencies();
+            if (!loadDeps || !loadDeps.length)
+              return true;
+            return loadDeps.some(name => !!compiledClasses[name]);
+          });
           
-          var promises = this.__applications.map(application => {
+          var promises = appsThisTime.map(application => {
             var appEnv = qx.tool.compiler.utils.Values.merge({}, compileEnv, application.getEnvironment());
             application.calcDependencies();
             if (application.getFatalCompileErrors()) {

--- a/lib/qx/tool/compiler/makers/Maker.js
+++ b/lib/qx/tool/compiler/makers/Maker.js
@@ -35,6 +35,11 @@ const mkParentPath = util.promisify(util.mkParentPath);
 module.exports = qx.Class.define("qx.tool.compiler.makers.Maker", {
   extend: qx.core.Object,
   type: "abstract",
+  
+  construct: function() {
+    this.base(arguments);
+    this._compiledClasses = {};
+  },
 
   properties: {
     /** Database filename relative to the target's output directory; if null, defaults to db.json; absolute paths can be used */
@@ -80,7 +85,13 @@ module.exports = qx.Class.define("qx.tool.compiler.makers.Maker", {
   },
 
   members: {
+    /** {Analyser} current analyser (created on demand) */
     _analyser: null,
+    
+    /** Lookup of classes which have been compiled this session; this is a map where the keys are
+     * the class name and the value is `true`, it is erased periodically 
+     */
+    _compiledClasses: null,
     
     /**
      * Makes the application
@@ -174,7 +185,25 @@ module.exports = qx.Class.define("qx.tool.compiler.makers.Maker", {
         return this._analyser; 
       }
       this._analyser = this._createAnalyser();
+      this._analyser.addListener("compiledClass", evt => {
+        let data = evt.getData(); 
+        this._compiledClasses[data.classFile.getClassName()] = true;
+      });
       return this._analyser;
+    },
+    
+    /**
+     * Returns a list of classes which have been compiled in this session
+     * 
+     * @param eraseAfter {Boolean?} if true, the list is reset after returning
+     * @return {Map} list of class names that have been compiled
+     */
+    getRecentlyCompiledClasses(eraseAfter) {
+      let classes = this._compiledClasses;
+      if (eraseAfter) {
+        this._compiledClasses = {};
+      }
+      return classes;
     },
 
     /**

--- a/lib/qx/tool/compiler/targets/BuildTarget.js
+++ b/lib/qx/tool/compiler/targets/BuildTarget.js
@@ -80,8 +80,10 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
       var application = compileInfo.application;
       var targetUri = t._getOutputRootUri(application);
       var appRootDir = this.getApplicationRoot(application);
+      
+      // ResourceUri does not have a trailing "/" because qx.util.ResourceManager.toUri always adds one
       var mapTo = this.getPathMapping(path.join(appRootDir, this.getOutputDir(), "resource"));
-      var resourceUri = mapTo ? mapTo : targetUri + "resource/";
+      var resourceUri = mapTo ? mapTo : targetUri + "resource";
       
       compileInfo.build = { 
           parts: {}

--- a/lib/qx/tool/compiler/targets/SourceTarget.js
+++ b/lib/qx/tool/compiler/targets/SourceTarget.js
@@ -55,8 +55,10 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.SourceTarget", {
 
       var mapTo = this.getPathMapping(path.join(appRootDir, this.getOutputDir(), "transpiled/"));
       var sourceUri = mapTo ? mapTo : targetUri + "transpiled/";
+      
+      // ResourceUri does not have a trailing "/" because qx.util.ResourceManager.toUri always adds one
       mapTo = this.getPathMapping(path.join(appRootDir, this.getOutputDir(), "resource"));
-      var resourceUri = mapTo ? mapTo : targetUri + "resource/";
+      var resourceUri = mapTo ? mapTo : targetUri + "resource";
 
 
       application.getRequiredLibraries().forEach(ns => {


### PR DESCRIPTION
primarily this reduces the compile time with `qx compile --watch` by only recompiling those applications that need it, ie those that are affected by class changes.
also adds `--no-bundling` to command line for `qx compile` to temporarily disable bundling.
reverts https://github.com/qooxdoo/qooxdoo-compiler/pull/327, and fixes the issue with slashes in `externalResources`

This should fix the issues experienced by @hkollmann @oetiker @zaucker 