### PR TITLE
Speed up 'qx contrib update' by including only highest minor/patch versions

### DIFF
--- a/lib/qx/tool/cli/commands/contrib/Update.js
+++ b/lib/qx/tool/cli/commands/contrib/Update.js
@@ -49,6 +49,14 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
             alias: "S",
             describe: "Search GitHub for repos (as opposed to using the cached nightly data)"
           },
+          "all-versions": {
+            alias: "a",
+            describe: "Retrieve all releases (as opposed to the latest minor/patch release of each major release)"
+          },
+          "prereleases": {
+            alias: "p",
+            describe: "Include prereleases"
+          },
           "verbose": {
             alias: "v",
             describe: "Verbose logging"
@@ -189,12 +197,30 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
             console.error("Error retrieving releases: " + e);
             continue;
           }
+
+          // filter releases to speed up updates
+          let releases = releases_data.data
+            // filter out invalid release names and prereleases unless "--all-versions"
+            .filter(r => argv["all-versions"] ? true :
+              (semver.valid(r.tag_name, true) && (!semver.prerelease(r.tag_name, true) || argv["prereleases"]))
+            )
+            // attach a clean version number
+            .map(r => {
+              r.version = semver.valid(r.tag_name, true);
+              return r;
+            })
+            // sort by version number
+            .sort((a, b) => semver.compare(a.version, b.version))
+            // use only the latest minor/patch unless "--all-versions"
+            .filter((r, i, a) => argv["all-versions"] ? true : (i === a.length-1 || semver.major(a[i+1].version) > semver.major(r.version)));
+
+          let versions = releases.map(r => r.version);
           if (argv.verbose) {
-            console.info(`>>> ${name} has ${releases_data.data.length} release(s).`);
+            console.info(`>>> Retrieved ${releases.length} release(s) of ${name}: ${versions.join(", ")}.`);
           }
 
           // get Manifest.json of each release to determine compatible qooxdoo versions
-          for (let release of releases_data.data) {
+          for (let release of releases) {
             let tag_name = release.tag_name;
             let releases = repos_data[name].releases;
 
@@ -232,7 +258,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
               // no qooxdoo.json
               if (e.message.match(/404/)) {
                 if (argv.verbose) {
-                  console.log(`!!! File does not exist.`);
+                  console.log(`>>> No qooxdoo.json`);
                 }
               } else if (argv.verbose) {
                 console.warn(`!!! Error: ${e.message}`);


### PR DESCRIPTION
Fixes #324

By default, ignores all versions except the highest minor/patch of each major version. This can be overridden by passing "--all-versions". Prereleases are also ignored unless you pass "--prereleases".