### PR TITLE
Fix bug with qx contrib update where Manifest path in root was malformed

### DIFF
--- a/lib/qx/tool/cli/commands/contrib/Update.js
+++ b/lib/qx/tool/cli/commands/contrib/Update.js
@@ -26,6 +26,7 @@ const Repository = require("github-api/dist/components/Repository");
 const fetch = require("node-fetch");
 const semver = require("semver");
 const inquirer = require("inquirer");
+const path = require("upath");
 
 
 
@@ -225,7 +226,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
             let releases = repos_data[name].releases;
 
             // list of paths to manifest files, default is Manifest.json in the root dir
-            let manifests = [{path: "Manifest.json"}];
+            let manifests = [{path: "."}];
 
             // can be overridden by a qoxdoo.json in the root dir
             let qooxdoo_data;
@@ -266,19 +267,14 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
             }
 
             // create a list of contribs via their manifests
-            for (let [index, {path}] of manifests.entries()) {
+            for (let [index, {path:manifest_path}] of manifests.entries()) {
               let manifest_data;
-              if (path !== "Manifest.json") {
-                if (path.substr(0, 2) === "./") {
-                  path = path.substr(2);
-                }
-                path += "/Manifest.json";
-              }
+              manifest_path = path.join(manifest_path, "Manifest.json");
               try {
                 if (argv.verbose) {
-                  console.log(`>>> Retrieving Manifest file '${path}' for ${name} ${tag_name}...`);
+                  console.log(`>>> Retrieving Manifest file '${manifest_path}' for ${name} ${tag_name}...`);
                 }
-                manifest_data = await repository.getContents(tag_name, path, true);
+                manifest_data = await repository.getContents(tag_name, manifest_path, true);
               } catch (e) {
                 if (e.message.match(/404/)) {
                   if (argv.verbose) {
@@ -345,9 +341,12 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
 
               qx_versions = qx_version_range;
               let info = data.info;
-              manifests[index] = {path,
+              // add information to manifest index
+              manifests[index] = {
+                path: manifest_path,
                 qx_versions,
-                info};
+                info
+              };
               num_libraries++;
               if (argv.verbose) {
                 console.log(`>>> ${name} ${tag_name}: Found '${info.name}' contrib (compatible with ${qx_versions})`);


### PR DESCRIPTION
This happened only in repos that have a qooxdoo.json and was therefore not noticed yet. 