### PR TITLE
Renames "qx upgrade" to "qx migrate"

### DIFF
--- a/lib/qx/tool/cli.js
+++ b/lib/qx/tool/cli.js
@@ -31,7 +31,7 @@ require("./cli/commands/Create.js");
 require("./cli/commands/Lint.js");
 require("./cli/commands/MConfig.js");
 require("./cli/commands/Serve.js");
-require("./cli/commands/Upgrade.js");
+require("./cli/commands/Migrate.js");
 require("./cli/commands/add/Class.js");
 require("./cli/commands/add/Script.js");
 require("./cli/commands/contrib/Install.js");

--- a/lib/qx/tool/cli/Cli.js
+++ b/lib/qx/tool/cli/Cli.js
@@ -54,7 +54,7 @@ qx.Class.define("qx.tool.cli.Cli", {
           "Create",
           "Lint",
           "Serve",
-          "Upgrade"
+          "Migrate"
         ],
         "qx.tool.cli.commands");
       yargs

--- a/lib/qx/tool/cli/commands/Migrate.js
+++ b/lib/qx/tool/cli/commands/Migrate.js
@@ -35,7 +35,7 @@ require("./Command");
  * Command to initialise a new qooxdoo application, or upgrade an old (pre-6.0) application
  *
  */
-qx.Class.define("qx.tool.cli.commands.Upgrade", {
+qx.Class.define("qx.tool.cli.commands.Migrate", {
   extend: qx.tool.cli.commands.Command,
 
   statics: {
@@ -44,9 +44,9 @@ qx.Class.define("qx.tool.cli.commands.Upgrade", {
      */
     getYargsCommand: function() {
       return {
-        command: "upgrade [options]",
-        desc: "upgrades a qooxdoo application",
-        usage: "upgrade",
+        command: "migrate [options]",
+        desc: "migrates a qooxdoo application to the next major version",
+        usage: "migrate",
         builder: {
           "verbose": {
             alias : "v",
@@ -55,7 +55,7 @@ qx.Class.define("qx.tool.cli.commands.Upgrade", {
           }
         },
         handler: function(argv) {
-          return new qx.tool.cli.commands.Upgrade(argv)
+          return new qx.tool.cli.commands.Migrate(argv)
             .process()
             .catch(e => {
               console.error(e.stack || e.message);


### PR DESCRIPTION
goal is to to differentiate from "qx contrib upgrade" and to better
describe what the command is doing