### PR TITLE
Additions to qx list

### DIFF
--- a/docs/cli/contrib.md
+++ b/docs/cli/contrib.md
@@ -88,7 +88,18 @@ command needs to be executed inside your project folder, since it expects
 contrib list` retrieves the version of the qooxdoo framework that the current
 project depends on and filters the list of available contributions accordingly.
 The list displays the names of the repositories and the names of the contained
-contrib libraries that will be installed.
+contrib libraries that will be installed. It has the following options:
+
+```
+Options:
+  --all, -a        Show all versions, including incompatible ones
+  --json, -j       Output list as JSON literal
+  --installed, -i  Show only installed libraries
+  --match, -m      Filter by regular expression (case-insensitive)
+  --libraries, -l  List libraries only (no repositories)
+  --short, -s      Omit title and description to make list more compact
+  --noheaders, -H  Omit header and footer
+```
 
 You can then install any contrib library from this list by executing `qx contrib
 install <URI>`. The URI takes the form `github_user/repository[/path]`: the first
@@ -257,6 +268,21 @@ Note that all libraries in the repository must have the same version number,
 because dependencies are managed and checked on the level of the repository, not
 of the library. When you `qx contrib publish` the repository, the versions of
 all libraries will be set to the one of the main library.
+
+## How to hide your contrib from being listed
+
+If you delete the contrib repository on GitHub, it will be removed from the
+contrib registry when the registry is regenerated nightly. However, there might
+be situations in which you want the library to be accessible without showing up 
+in `qx list`, for example, when you rename or deprecate a library, or if you
+create a fork that your application depends on, but which you don't want others
+to use. 
+
+To achieve this, simply add `(unlisted)` or `(deprecated)` (with the 
+brackets) to the description of the repository on GitHub (the one below the 
+name of the repository). This way, the library will not be listed unless `--all`
+is passed to `qx list`.
+
 
 ## Install contribs automatically
 

--- a/lib/qx/tool/cli/Cli.js
+++ b/lib/qx/tool/cli/Cli.js
@@ -42,8 +42,7 @@ qx.Class.define("qx.tool.cli.Cli", {
         
       Type qx <command> --help for options and subcommands.`;
 
-      let yargs = require("yargs")
-        .locale("en");
+      let yargs = require("yargs").locale("en");
       qx.tool.cli.Cli.addYargsCommands(yargs,
         [
           "Add",
@@ -57,11 +56,13 @@ qx.Class.define("qx.tool.cli.Cli", {
           "Migrate"
         ],
         "qx.tool.cli.commands");
-      yargs
+      return yargs
         .usage(title)
         .demandCommand()
         .strict()
+        .version()
         .showHelpOnFail()
+        .help()
         .argv;
     }
   },

--- a/lib/qx/tool/cli/commands/Add.js
+++ b/lib/qx/tool/cli/commands/Add.js
@@ -39,7 +39,8 @@ qx.Class.define("qx.tool.cli.commands.Add", {
 
           return yargs
             .demandCommand()
-            .showHelpOnFail();
+            .showHelpOnFail()
+            .help();
         },
         handler : function(argv) {
         }

--- a/lib/qx/tool/cli/commands/Contrib.js
+++ b/lib/qx/tool/cli/commands/Contrib.js
@@ -35,7 +35,7 @@ qx.Class.define("qx.tool.cli.commands.Contrib", {
     getYargsCommand: function() {
       return {
         command : "contrib <command> [options]",
-        desc : "manages qooxdoo contrib libraries",
+        desc : "Manages qooxdoo contrib libraries",
         builder : function(yargs) {
           qx.tool.cli.Cli.addYargsCommands(yargs, [
             "Install",
@@ -48,7 +48,8 @@ qx.Class.define("qx.tool.cli.commands.Contrib", {
 
           return yargs
             .demandCommand()
-            .showHelpOnFail();
+            .showHelpOnFail()
+            .help();
         },
         handler : function(argv) {
         }

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -50,10 +50,27 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
             alias: "j",
             describe: "Output list as JSON literal"
           },
+          installed: {
+            alias: "i",
+            describe: "Show only installed libraries"
+          },
           match: {
             alias: "m",
             describe: "Filter by regular expression (case-insensitive)"
+          },
+          "libraries": {
+            alias: "l",
+            describe: "List libraries only (no repositories)"
+          },
+          "short": {
+            alias: "s",
+            describe: "Omit title and description to make list more compact"
+          },
+          "noheaders": {
+            alias: "H",
+            describe: "Omit header and footer"
           }
+
         },
         handler: function(argv) {
           return new qx.tool.cli.commands.contrib.List(argv)
@@ -131,22 +148,26 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
       }
 
       // list output
+      let columns = this.argv.short ?
+        ["name", "installedVersion", "latestVersion", "latestCompatible"] :
+        ["name", "title", "description", "installedVersion", "latestVersion", "latestCompatible"];
       let columnify_options = {
+        showHeaders: !this.argv.noheaders,
         columnSplitter: "   ",
-        columns: ["name", "title", "description", "installedVersion", "latestVersion", "latestCompatible"],
+        columns,
         config: {
           title: {maxWidth:25},
           description: {maxWidth: 60},
           installedVersion: {
-            headingTransform : heading => "INSTALLED",
+            headingTransform : () => "INSTALLED",
             dataTransform: data => (data === "false" ? "" : data)
           },
           latestVersion: {
-            headingTransform : heading => "LATEST",
+            headingTransform : () => "LATEST",
             dataTransform: data => (data === "false" ? "-" : data)
           },
           latestCompatible : {
-            headingTransform : heading => "COMPATIBLE",
+            headingTransform : () => "COMPATIBLE",
             dataTransform: data => (data === "false" ? "-" : data)
           }
         }
@@ -183,7 +204,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
           }
         }
         // add title to multiple-library repos
-        if (repo_libs.length > 1) {
+        if (repo_libs.length > 1 && !(this.argv["only-libraries"] || this.argv.short)) {
           expanded_list.push({
             type: "repository",
             name: repo.name,
@@ -209,15 +230,20 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
         expanded_list = expanded_list.filter(lib => lib.name.match(exp) || lib.title.match(exp) || lib.description.match(exp));
       }
 
+      // show only installed libraries if requested
+      expanded_list = expanded_list.filter(lib => Boolean(lib.installedVersion));
+
       if (this.argv.json) {
         console.info(JSON.stringify(expanded_list, null, 2));
       } else if (!this.argv.quiet) {
         console.info(columnify(expanded_list, columnify_options));
-        console.info();
-        console.info("Note on columns: LATEST: Latest release that can be installed with this CLI;");
-        console.info("                 COMPATIBLE: Latest release that is semver-compatible with the qooxdoo version used.");
-        if (!this.argv.all) {
-          console.info("To see all libraries, including potentially incompatible ones, use 'qx contrib list --all'.");
+        if (!this.argv.noheaders) {
+          console.info();
+          console.info("Note on columns: LATEST: Latest release that can be installed with this CLI;");
+          console.info("                 COMPATIBLE: Latest release that is semver-compatible with the qooxdoo version used.");
+          if (!this.argv.all) {
+            console.info("To see all libraries, including potentially incompatible ones, use 'qx contrib list --all'.");
+          }
         }
       }
 
@@ -249,8 +275,9 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
       for (let repo_name of repos_cache.list) {
         let repo_data = repos_cache.data[repo_name];
 
-        // filter out deprecated repos unless --all
-        if (repo_data.topics && repo_data.topics.includes("deprecated") && !this.argv.all) {
+        // filter out repositories that are deprecated or should not be listed unless --all
+        let d = repo_data.description;
+        if (!this.argv.all && d && (d.includes("(deprecated)") || d.includes("(unlisted)"))) {
           continue;
         }
 
@@ -347,7 +374,6 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
         }
 
         // add to list
-
         this.__repositories.push({
           name: repo_name,
           description,

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -45,6 +45,10 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
           quiet: {
             alias: "q",
             describe: "No output"
+          },
+          json: {
+            alias: "j",
+            describe: "Output list as JSON literal"
           }
         },
         handler: function(argv) {
@@ -125,6 +129,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
       // list output
       let columnify_options = {
         columnSplitter: "   ",
+        columns: ["name", "title", "description", "installedVersion", "latestVersion", "latestCompatible"],
         config: {
           title: {maxWidth:25},
           description: {maxWidth: 60},
@@ -156,9 +161,13 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
       let expanded_list = [];
       for (let repo of list) {
         let repo_libs = [];
+        if (!qx.lang.Type.isArray(this.__libraries[repo.name])) {
+          continue;
+        }
         for (let library of this.__libraries[repo.name]) {
           if (semver.eq(library.version, repo.latestVersion)) {
             repo_libs.push({
+              type: "library",
               name: path.join(repo.name, library.path || ""),
               title: library.name,
               description: library.summary || repo.description,
@@ -171,8 +180,11 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
         // add title to multiple-library repos
         if (repo_libs.length > 1) {
           expanded_list.push({
+            type: "repository",
             name: repo.name,
+            title: "",
             description: repo.description,
+            installedVersion: "",
             latestVersion: repo.latestVersion,
             latestCompatible: repo.latestCompatible
           });
@@ -180,7 +192,9 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
         expanded_list = expanded_list.concat(repo_libs);
       }
 
-      if (!this.argv.quiet) {
+      if (this.argv.json) {
+        console.info(JSON.stringify(expanded_list, null, 2));
+      } else if (!this.argv.quiet) {
         console.info(columnify(expanded_list, columnify_options));
         console.info();
         console.info("Note on columns: LATEST: Latest release that can be installed with this CLI;");

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -188,6 +188,13 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
             latestVersion: repo.latestVersion,
             latestCompatible: repo.latestCompatible
           });
+          if (!this.argv.json) {
+            // add an indent to group libraries in a repository
+            repo_libs = repo_libs.map(lib => {
+              lib.name = "-- " + lib.name;
+              return lib;
+            });
+          }
         }
         expanded_list = expanded_list.concat(repo_libs);
       }

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -49,6 +49,10 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
           json: {
             alias: "j",
             describe: "Output list as JSON literal"
+          },
+          match: {
+            alias: "m",
+            describe: "Filter by regular expression (case-insensitive)"
           }
         },
         handler: function(argv) {
@@ -147,16 +151,17 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
           }
         }
       };
+      // filter by compatibility unless --all
       let list =
         this.argv.all ?
           this.__repositories :
           this.__repositories.filter(item => item.latestCompatible);
+      // sort
       list.sort((l, r) => {
         l = l.name.toLowerCase();
         r = r.name.toLowerCase();
         return l < r ? -1 : l > r ? 1 : 0;
       });
-
       // list all libraries contained in a repo
       let expanded_list = [];
       for (let repo of list) {
@@ -197,6 +202,11 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
           }
         }
         expanded_list = expanded_list.concat(repo_libs);
+      }
+      // filter by regular expression if requested
+      if (this.argv.match) {
+        let exp = new RegExp(this.argv.match, "i");
+        expanded_list = expanded_list.filter(lib => lib.name.match(exp) || lib.title.match(exp) || lib.description.match(exp));
       }
 
       if (this.argv.json) {

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -70,6 +70,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
             alias: "H",
             describe: "Omit header and footer"
           }
+
         },
         handler: function(argv) {
           return new qx.tool.cli.commands.contrib.List(argv)

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -231,11 +231,16 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
       }
 
       // show only installed libraries if requested
-      expanded_list = expanded_list.filter(lib => Boolean(lib.installedVersion));
+      if (this.argv.installed) {
+        expanded_list = expanded_list.filter(lib => Boolean(lib.installedVersion));
+      }
 
+      // output list
       if (this.argv.json) {
+        // as JSON
         console.info(JSON.stringify(expanded_list, null, 2));
       } else if (!this.argv.quiet) {
+        // as columns
         console.info(columnify(expanded_list, columnify_options));
         if (!this.argv.noheaders) {
           console.info();

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -70,7 +70,6 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
             alias: "H",
             describe: "Omit header and footer"
           }
-
         },
         handler: function(argv) {
           return new qx.tool.cli.commands.contrib.List(argv)

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -248,6 +248,12 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
       // iterate over repositories
       for (let repo_name of repos_cache.list) {
         let repo_data = repos_cache.data[repo_name];
+
+        // filter out deprecated repos unless --all
+        if (repo_data.topics && repo_data.topics.includes("deprecated") && !this.argv.all) {
+          continue;
+        }
+
         let tag_names = repo_data.releases.list;
         let {description} = repo_data;
         let hasCompatibleRelease = false;

--- a/lib/qx/tool/cli/commands/contrib/Update.js
+++ b/lib/qx/tool/cli/commands/contrib/Update.js
@@ -182,7 +182,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
           let repository = new Repository(name, auth);
           repos_data[name] = {
             description: repo.description,
-            topics: repo.topics,
+            topics: repo.topics || [], // not yet in response data
             url: repo.url,
             releases: {
               list: [],

--- a/lib/qx/tool/cli/commands/contrib/Update.js
+++ b/lib/qx/tool/cli/commands/contrib/Update.js
@@ -182,7 +182,6 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
           let repository = new Repository(name, auth);
           repos_data[name] = {
             description: repo.description,
-            topics: repo.topics || [], // not yet in response data
             url: repo.url,
             releases: {
               list: [],

--- a/lib/qx/tool/cli/commands/contrib/Update.js
+++ b/lib/qx/tool/cli/commands/contrib/Update.js
@@ -182,6 +182,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Update", {
           let repository = new Repository(name, auth);
           repos_data[name] = {
             description: repo.description,
+            topics: repo.topics,
             url: repo.url,
             releases: {
               list: [],

--- a/test/test.linux.sh
+++ b/test/test.linux.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -x
+echo "Testing qooxdoo-compiler version $(qx --version)"
+echo
 
 cd test
 node test-deps.js
@@ -11,9 +13,12 @@ qx create myapp -I --type server -v || exit $?
 cd myapp
 qx compile -v --clean || exit $?
 node compiled/source/myapp/myapp.js || exit $?
+# test qx contrib list
+qx contrib update  -v || exit $?
+qx contrib list    -v || exit $?
+qx contrib list --all --short --noheaders || exit $?
+qx contrib list --json --match==qooxdoo/ || exit $?
 # test add contrib
-qx contrib update  -v|| exit $?
-qx contrib list    -v|| exit $?
 qx contrib install oetiker/UploadWidget -v --release v1.0.1 || exit $?
 qx contrib install cboulanger/qx-contrib-Dialog -v || exit $?
 qx contrib install johnspackman/UploadMgr -v || exit $?
@@ -21,22 +26,26 @@ qx contrib install ergobyte/qookery/qookeryace -v || exit $?
 qx contrib install ergobyte/qookery/qookerymaps -v || exit $?
 qx compile -v --clean || exit $?
 node compiled/source/myapp/myapp.js || exit $?
+qx contrib list --installed --short --noheaders
 # test reinstall contrib
 qx clean || exit $?
 qx contrib install -v || exit $?
 qx compile -v --clean || exit $?
 node compiled/source/myapp/myapp.js
+qx contrib list -isH
 # test remove contrib
 qx contrib remove oetiker/UploadWidget -v || exit $?
 qx contrib remove ergobyte/qookery/qookeryace -v || exit $?
 qx contrib remove ergobyte/qookery/qookerymaps -v || exit $?
 qx compile -v --clean || exit $?
 node compiled/source/myapp/myapp.js || exit $?
+qx contrib list --installed --short --noheaders
 # test install without manifest
 qx clean || exit $?
 qx contrib install ergobyte/qookery -v || exit $?
 qx compile -v --clean || exit $?
 node compiled/source/myapp/myapp.js || exit $?
+qx contrib list --installed --short --noheaders
 # test add class and add script
 qx add class myapp.Window --extend=qx.ui.window.Window || exit $?
 qx add script ../testdata/npm/script/jszip.js --rename=zip.js || exit $?

--- a/test/test.linux.sh
+++ b/test/test.linux.sh
@@ -16,8 +16,8 @@ node compiled/source/myapp/myapp.js || exit $?
 # test qx contrib list
 qx contrib update  -v || exit $?
 qx contrib list    -v || exit $?
-qx contrib list --all --short --noheaders || exit $?
-qx contrib list --json --match==qooxdoo/ || exit $?
+qx contrib list --all --short --noheaders --match=qooxdoo/ || exit $?
+qx contrib list --json --installed || exit $?
 # test add contrib
 qx contrib install oetiker/UploadWidget -v --release v1.0.1 || exit $?
 qx contrib install cboulanger/qx-contrib-Dialog -v || exit $?


### PR DESCRIPTION
This adds a couple of new options to `qx contrib list`:

```
  --json, -j       Output list as JSON literal
  --installed, -i  Show only installed libraries
  --match, -m      Filter by regular expression (case-insensitive)
  --libraries, -l  List libraries only (no repositories)
  --short, -s      Omit title and description to make list more compact
  --noheaders, -H  Omit header and footer
```
The PR also adds support for hiding repositories from being listed in `qx contrib list`, by adding `(unlisted)` or `(deprecated)` to the repository description on GitHub. I tried to do that with GitHub Topics, but they are not supported by the NPM GitHub API client that we currently use.

Also, it adds the `--version`/`-v` option to `qx` so that now you can do `echo "qx is version $(qx --version)!"` in your scripts.