### PR TITLE
Fixes #344 and #353

### DIFF
--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -618,6 +618,13 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
             requires["qooxdoo-sdk"] = range;
           }
         }
+        // default to empty contrib map
+        if (!qx.lang.Type.isObject(contribs)) {
+          if (this.argv.verbose) {
+            console.warn("No contrib information available.");
+          }
+          contribs={};
+        }
         if (requires) {
           for (let req of Object.getOwnPropertyNames(requires)) {
             let libVer = requires[req];
@@ -637,9 +644,6 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
                 break;
               }
               default: {
-                if (!qx.lang.Type.isObject(contribs)) {
-                  return [`No library information exists. You need to execute 'qx contrib list && qx contrib install ${req}' first.`];
-                }
                 let l = libs.find(entry => path.relative("", entry.getRootDir()) === contribs[req]);
                 if (!l) {
                   errors.push(`${lib.getNamespace()}: Cannot find required library with namespace ${req}`);

--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -21,7 +21,7 @@ const process = require("process");
 const Gauge = require("gauge");
 const fs = qx.tool.compiler.utils.Promisify.fs;
 const semver = require("semver");
-const path = require("upath")
+const path = require("upath");
 
 require("app-module-path").addPath(process.cwd() + "/node_modules");
 
@@ -50,6 +50,12 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
             describe: "Set the target type: source or build or class name. Default is first target in config file",
             requiresArg: true,
             type: "string"
+          },
+          "download": {
+            alias: "d",
+            describe: "Whether to automatically download missing libraries",
+            type: "boolean",
+            default: true
           },
           "output-path": {
             describe: "Base path for output",
@@ -147,7 +153,8 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           },
           "warnAsError": {
             alias: "w",
-            describe: "handle warnings as error"
+            default: false,
+            describe: "Handle compiler warnings as error"
           },
           "write-library-info": {
             describe: "Write library information to the script, for reflection",
@@ -331,7 +338,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
         if (this.argv.verbose) {
           console.log("\nCompleted all applications, libraries used are:");
           maker.getAnalyser().getLibraries().forEach(lib => {
-            console.log("    " + lib.getRootDir());
+            console.log(`   ${lib.getNamespace()} (${lib.getRootDir()})`);
           });
         }
       });
@@ -580,7 +587,11 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
 
       if (!data.libraries.every(libData => fs.existsSync(libData + "/Manifest.json"))) {
         console.log("One or more libraries not found - trying to install them from library repository...");
-        await (new qx.tool.cli.commands.contrib.Install({quiet:true})).process();
+        const installer = new qx.tool.cli.commands.contrib.Install({
+          quiet: true,
+          save: false
+        });
+        await installer.process();
       }
 
       const addLibraryAsync = qx.tool.compiler.utils.Promisify.promisify(maker.addLibrary, maker);
@@ -598,69 +609,97 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       return maker;
     },
 
+    /**
+     * Checks the dependencies of the current library
+     * @param {qx.tool.compiler.makers.Maker} maker
+     *    The maker object
+     * @param {Object|*} contribs
+     *    If given, an object mapping library uris to
+     *    {@link qx.tool.compiler.app.Library} objects
+     * @return {Promise<Array>} Array of error messages
+     * @private
+     */
     __checkDependencies: async function(maker, contribs) {
       let errors = [];
       let libs = maker.getAnalyser().getLibraries();
       const SDK_VERSION = await this.getUserQxVersion();
       // check all requieres
-      libs.forEach(lib => {
+      for (let lib of libs) {
         let requires = lib.getRequires();
+        if (!requires) {
+          requires = {};
+        }
+        if (!contribs) {
+          contribs = {};
+        }
         // check for qooxdoo-range
         let range = lib.getLibraryInfo()["qooxdoo-range"];
         if (range) {
           if (this.argv.verbose) {
             console.warn(`${lib.getNamespace()}: The configuration setting "qooxdoo-range" in Manifest.json has been deprecated in favor of "requires.qooxdoo-sdk")`);
           }
-          if (!requires) {
-            requires = {};
-          }
           if (!requires["qooxdoo-sdk"]) {
             requires["qooxdoo-sdk"] = range;
           }
         }
-        // default to empty contrib map
-        if (!qx.lang.Type.isObject(contribs)) {
-          if (this.argv.verbose) {
-            console.warn("No contrib information available.");
+        let requires_uris = Object.getOwnPropertyNames(requires).filter(name => !name.startsWith("qooxdoo-"));
+        let contrib_libs = Object.getOwnPropertyNames(contribs);
+        if (requires_uris.length > 0 && contrib_libs.length === 0) {
+            // if we don't have contrib data
+            if (this.argv.download) {
+              // but we're instructed to download the libraries
+              if (this.argv.verbose) {
+                console.info(`>>> Installing latest compatible version of required libraries...`);
+              }
+              const installer = new qx.tool.cli.commands.contrib.Install({
+                verbose: this.argv.verbose,
+                save: false // save to contrib.json only, not to manifest
+              });
+              await installer.process();
+              throw new qx.tool.cli.Utils.UserError("Added missing library information from Manifest. Please restart the compilation.");
+            } else {
+              throw new qx.tool.cli.Utils.UserError("No library information available. Try 'qx compile --download'");
+            }
           }
-          contribs={};
-        }
-        if (requires) {
-          for (let req of Object.getOwnPropertyNames(requires)) {
-            let libVer = requires[req];
-            switch (req) {
+
+          for (let reqUri of Object.getOwnPropertyNames(requires)) {
+            let reqVersion = requires[reqUri];
+            switch (reqUri) {
+              // npm release only
               case "qooxdoo-compiler": {
                 let qxVer = qx.tool.compiler.Version.VERSION;
-                if (!semver.satisfies(qxVer, libVer, {loose: true})) {
-                  errors.push(`${lib.getNamespace()}: Needs qooxdoo-compiler version ${libVer}, found ${qxVer}`);
+                if (!semver.satisfies(qxVer, reqVersion, {loose: true})) {
+                  errors.push(`${lib.getNamespace()}: Needs qooxdoo-compiler version ${reqVersion}, found ${qxVer}`);
                 }
                 break;
               }
+              // npm release only
               case "qooxdoo-sdk": {
                 let qxVer = SDK_VERSION;
-                if (!semver.satisfies(qxVer, libVer, {loose: true})) {
-                  errors.push(`${lib.getNamespace()}: Needs qooxdoo-sdk version ${libVer}, found ${qxVer}`);
+                if (!semver.satisfies(qxVer, reqVersion, {loose: true})) {
+                  errors.push(`${lib.getNamespace()}: Needs qooxdoo-sdk version ${reqVersion}, found ${qxVer}`);
                 }
                 break;
               }
+              // github repository release or commit-ish identifier
               default: {
-                let l = libs.find(entry => path.relative("", entry.getRootDir()) === contribs[req]);
+                let l = libs.find(entry => path.relative("", entry.getRootDir()) === contribs[reqUri]);
                 if (!l) {
-                  errors.push(`${lib.getNamespace()}: Cannot find required library with namespace ${req}`);
-                } else {
-                  let qxVer = l.getLibraryInfo().version;
-                  if (!semver.valid(qxVer, {loose: true})) {
-                    console.warn(`${req}: Version is not valid: ${qxVer}`);
-                  } else if (!semver.satisfies(qxVer, libVer, {loose: true})) {
-                    errors.push(`${lib.getNamespace()}: Needs ${req} version ${libVer}, found ${qxVer}`);
-                  }
+                  errors.push(`${lib.getNamespace()}: Cannot find required library '${reqUri}'`);
+                  break;
                 }
-              }
+                // github release in contrib registry
+                let libVersion = l.getLibraryInfo().version;
+                if (!semver.valid(libVersion, {loose: true})) {
+                  console.warn(`${reqUri}: Version is not valid: ${libVersion}`);
+                } else if (!semver.satisfies(libVersion, reqVersion, {loose: true})) {
+                  errors.push(`${lib.getNamespace()}: Needs ${reqUri} version ${reqVersion}, found ${libVersion}`);
+                }
                 break;
             }
           }
         }
-      });
+      }
       return errors;
     },
 

--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -637,7 +637,10 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
                 break;
               }
               default: {
-                let l = libs.find(entry => path.relative("", entry.getRootDir()) == contribs[req]);
+                if (!qx.lang.Type.isObject(contribs)) {
+                  return [`No library information exists. You need to execute 'qx contrib list && qx contrib install ${req}' first.`];
+                }
+                let l = libs.find(entry => path.relative("", entry.getRootDir()) === contribs[req]);
                 if (!l) {
                   errors.push(`${lib.getNamespace()}: Cannot find required library with namespace ${req}`);
                 } else {

--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -41,14 +41,14 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
         builder: {
           "release" : {
             alias: "r",
-            describe: "use a specific release tag instead of the tag of the latest compatible release",
+            describe: "Use a specific release tag instead of the tag of the latest compatible release",
             nargs: 1,
             requiresArg: true,
             type: "string"
           },
           "ignore" : {
             alias: "i",
-            describe: "ignore unmatch of qooxdoo"
+            describe: "Ignore unmatch of qooxdoo"
           },
           "verbose": {
             alias: "v",
@@ -57,6 +57,11 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
           "quiet": {
             alias: "q",
             describe: "No output"
+          },
+          "save": {
+            alias: "s",
+            default: true,
+            describe: "Save the installed libraries as permanent dependencies"
           }
         },
         handler: function(argv) {
@@ -88,23 +93,22 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       await this.process();
     },
 
+
     /**
      * Installs a contrib library
      */
     process: async function() {
-      let repos_cache = this.getCache().repos;
-      if (repos_cache.list.length === 0) {
-        if (!this.argv.quiet) {
-          console.info(">>> Updating cache...");
-        }
-        this.clearCache();
-        // implicit update
-        await (new qx.tool.cli.commands.contrib.Update({quiet:true})).process();
-        await (new qx.tool.cli.commands.contrib.List({quiet:true})).process();
-      }
+      await this.__updateCache();
+      await this.__readConfigData();
 
+      // if no library uri has been passed install from contrib.json or Manifest.json
       if (!this.argv["contrib_uri@release_tag"]) {
-        await this.__loadFromContribJson();
+        if (this.__data.libraries.length) {
+          await this.__loadFromContribJson();
+        } else {
+          await this.__installDependenciesFromManifest(this.__manifest);
+          await this.__saveConfigData();
+        }
         return;
       }
 
@@ -116,28 +120,63 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
         [uri, id] = uri.split(/@/);
       }
 
-      // read manifest and contrib library data
+
+      // install library/libraries
+      if (!id || (qx.lang.Type.isString(id) && id.startsWith("v"))) {
+        // we use the latest or a given release
+        await this.__installFromRelease(uri, id, this.argv.save);
+      } else {
+        // arbitrary path into the code tree
+        await this.__installFromTree(uri, id, this.argv.save);
+      }
+
+      await this.__saveConfigData();
+
+      if (this.argv.verbose) {
+        console.info(">>> Done.");
+      }
+    },
+
+    /**
+     * Update repo cache
+     * @return {Promise<void>}
+     * @private
+     */
+    async __updateCache() {
+      let repos_cache = this.getCache().repos;
+      if (repos_cache.list.length === 0) {
+        if (!this.argv.quiet) {
+          console.info(">>> Updating cache...");
+        }
+        this.clearCache();
+        // implicit update
+        await (new qx.tool.cli.commands.contrib.Update({quiet:true})).process();
+        await (new qx.tool.cli.commands.contrib.List({quiet:true})).process();
+      }
+    },
+
+    /**
+     * Read manifest and contrib library data into (private) members
+     * @return {Promise<void>}
+     * @private
+     */
+    async __readConfigData() {
       this.__manifest = await qx.tool.compiler.utils.Json.loadJsonAsync("Manifest.json");
       if (!this.__manifest.requires) {
         this.__manifest.requires = {};
       }
       this.__data = await this.getContribData();
+    },
 
-      // install library/libraries
-      if (!id || (qx.lang.Type.isString(id) && id.startsWith("v"))) {
-        // we use the latest or a given release
-        await this.__installFromRelease(uri, id, true);
-      } else {
-        // arbitrary path into the code tree
-        await this.__installFromTree(uri, id, true);
-      }
-
-      // save data
+    /**
+     * Save manifest (unless --save==false) and contrib library data
+     * @return {Promise<void>}
+     * @private
+     */
+    async __saveConfigData() {
       await qx.tool.compiler.utils.Json.saveJsonAsync(this.getContribFileName(), this.__data);
-      await qx.tool.compiler.utils.Json.saveJsonAsync("Manifest.json", this.__manifest);
-
-      if (this.argv.verbose) {
-        console.info(">>> Done.");
+      if (this.argv.save) {
+        await qx.tool.compiler.utils.Json.saveJsonAsync("Manifest.json", this.__manifest);
       }
     },
 
@@ -182,10 +221,10 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       if (!tag_name) {
         let cache = this.getCache();
         if (cache.compat[qooxdoo_version] === undefined) {
-          if (!this.argv.quiet) {
+          if (this.argv.verbose && !this.argv.quiet) {
             console.info(">>> Updating cache...");
           }
-          await (new qx.tool.cli.commands.contrib.List({quiet:true})).process();
+          await (new qx.tool.cli.commands.contrib.List({quiet:true, all:true})).process();
           cache = this.getCache(true);
         }
         tag_name = cache.compat[qooxdoo_version][repo_name];
@@ -280,7 +319,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       if (index >= 0) {
         this.__data.libraries[index] = library_elem;
         if (this.argv.verbose && !this.argv.quiet) {
-          console.info(`>>> Updating already existing config.json entry for'${uri}'.`);
+          console.info(`>>> Updating already existing contrib.json entry for'${uri}'.`);
         }
       } else {
         this.__data.libraries.push(library_elem);
@@ -292,7 +331,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       if (!appsInstalled && this.argv.verbose) {
         console.info(`>>> No applications installed for ${uri}.`);
       }
-      let depsInstalled = await this.installDependencies(library_path);
+      let depsInstalled = await this.__installDependenciesFromPath(library_path);
       if (!depsInstalled && this.argv.verbose) {
         console.info(`>>> No dependencies installed for ${uri}.`);
       }
@@ -304,46 +343,75 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
     /**
      * Given a download path of a library, install its dependencies
      * @param {String} downloadPath
-     * @return {Promise<Boolean>}
+     * @return {Promise<Boolean>} Wether any libraries were installed
      */
-    installDependencies: async function(downloadPath) {
+    __installDependenciesFromPath: async function(downloadPath) {
       let manifest = await qx.tool.compiler.utils.Json.loadJsonAsync(path.join(downloadPath, "Manifest.json"));
       if (!manifest.requires) {
         return false;
       }
-      for (let lib_name of Object.getOwnPropertyNames(manifest.requires)) {
-        let lib_version = manifest.requires[lib_name];
-        switch (lib_name) {
+      return this.__installDependenciesFromManifest(manifest);
+    },
+
+    /**
+     * Given a library's manifest data, install its dependencies
+     * @param {Object} manifest
+     * @return {Promise<Boolean>} Wether any libraries were installed
+     */
+    async __installDependenciesFromManifest(manifest) {
+      for (let lib_uri of Object.getOwnPropertyNames(manifest.requires)) {
+        let lib_version = manifest.requires[lib_uri];
+        switch (lib_uri) {
           case "qooxdoo-compiler":
             break;
           case "qooxdoo-sdk": {
             let qxVer = await this.getUserQxVersion();
             if (!semver.satisfies(qxVer, lib_version, {loose: true}) && this.argv.ignore) {
               throw new qx.tool.cli.Utils.UserError(
-                `Contrib needs qooxdoo-sdk version ${lib_version}, found ${qxVer}`
+                `Library '${lib_uri}' needs qooxdoo-sdk version ${lib_version}, found ${qxVer}`
               );
             }
             break;
           }
           default: {
-            // remove path into repo to get repo name only
-            lib_name = lib_name.split(/\//).slice(0, 2).join("/");
-            let lib = this.getCache().repos.data[lib_name];
-            if (!lib) {
-              throw new qx.tool.cli.Utils.UserError(`${lib_name} is not in the library registry!`);
+            // version info is semver range -> released version
+            if (semver.validRange(lib_version)) {
+              let version = this.__getHighestCompatibleVersion(lib_uri, lib_version);
+              if (!version) {
+                throw new qx.tool.cli.Utils.UserError(`No satisfying version found for ${lib_uri}@${lib_version}!`);
+              }
+              await this.__installFromRelease(lib_uri, `v${version}`, false);
+              break;
             }
-            let versionList = [];
-            lib.releases.list.forEach(elem => versionList.push(elem.substring(1)));
-            let version = semver.maxSatisfying(versionList, lib_version, {loose: true});
-            if (!version) {
-              throw new qx.tool.cli.Utils.UserError(`No satisfying version found for ${lib_name}@${lib_version}!`);
+            // treat version info as tree-ish identifier
+            try {
+              await this.__installFromTree(lib_uri, lib_version, false);
+              break;
+            } catch (e) {
+              throw new qx.tool.cli.Utils.UserError(`Could not install ${lib_uri}@${lib_version}: ${e.message}`);
             }
-            await this.__installFromRelease(lib_name, `v${version}`); // todo: this breaks if release name does not start with "v"
-            break;
           }
         }
       }
       return true;
+    },
+
+    /**
+     * Given the URI of a library repo and a semver range, returns the highest
+     * release compatible with the semver range
+     * @param {String} lib_uri The URI of the library
+     * @param {String} lib_range The semver range
+     * @private
+     */
+    __getHighestCompatibleVersion(lib_uri, lib_range) {
+      let {repo_name} = this.__getUriInfo(lib_uri);
+      let lib = this.getCache().repos.data[repo_name];
+      if (!lib) {
+        throw new qx.tool.cli.Utils.UserError(`${lib_uri} is not in the library registry!`);
+      }
+      let versionList = [];
+      lib.releases.list.forEach(elem => versionList.push(elem.substring(1)));
+      return semver.maxSatisfying(versionList, lib_range, {loose: true});
     },
 
     /**
@@ -381,15 +449,17 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
     },
 
     /**
-     * Read and download libraries array from contrib.json
+     * Download repos listed in from contrib.json
      * @return {Promise<void>}
      * @private
      */
     __loadFromContribJson: async function() {
-      let contrib_json_path = process.cwd() + "/contrib.json";
-      let data = fs.existsSync(contrib_json_path) ? qx.tool.compiler.utils.Json.parseJson(fs.readFileSync(contrib_json_path, "utf-8")) : {libraries : []};
-      for (let i = 0; i < data.libraries.length; i++) {
-        await this.__download(data.libraries[i].repo_name, data.libraries[i].repo_tag);
+      if (this.argv.verbose) {
+        console.info(">>> Downloading libraries listed in contrib.json...");
+      }
+      let libraries = (await this.getContribData()).libraries;
+      for (let i = 0; i < libraries.length; i++) {
+        await this.__download(libraries[i].repo_name, libraries[i].repo_tag);
       }
     },
 

--- a/lib/qx/tool/cli/commands/contrib/List.js
+++ b/lib/qx/tool/cli/commands/contrib/List.js
@@ -218,7 +218,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.List", {
             latestVersion: repo.latestVersion,
             latestCompatible: repo.latestCompatible
           });
-          if (!this.argv.json) {
+          if (!this.argv.json && !this.argv.installed && !this.argv.match) {
             // add an indent to group libraries in a repository
             repo_libs = repo_libs.map(lib => {
               lib.name = "-- " + lib.name;

--- a/lib/qx/tool/cli/commands/contrib/Upgrade.js
+++ b/lib/qx/tool/cli/commands/contrib/Upgrade.js
@@ -56,7 +56,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Upgrade", {
       let data = await this.getContribData();
       let found = false;
       const installer = new qx.tool.cli.commands.contrib.Install({
-        quiet:this.argv.quiet,
+        quiet: this.argv.quiet,
         verbose: this.argv.verbose
       });
       for (const library of data.libraries) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7043,9 +7043,9 @@
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-diff": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "qooxdoo": "^6.0.0-alpha",
     "qooxdoo-sdk": "^6.0.0-alpha-20181226-a3c2b0b",
     "rimraf": "^2.6.2",
-    "semver": "^5.6.0",
+    "semver": "^5.7.0",
     "tmp": "0.0.33",
     "uglify-es": "^3.3.9",
     "upath": "^1.1.0",

--- a/test/bash/test-dependency-management.sh
+++ b/test/bash/test-dependency-management.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+echo
+echo "Test 1: qxl.test1, latest version"
+[[ -d myapp ]] && rm -rf myapp
+qx create myapp -I
+cd myapp
+qx contrib install qooxdoo/qxl.test1
+LIST=$(qx contrib list --short --noheaders --installed --all)
+echo "$LIST"
+COUNTLINES=$(echo "$LIST" | wc -l | tr -d ' ')
+[ "$COUNTLINES" == "3" ] || (echo "Installing dependencies failed" || exit 1)
+qx compile --feedback=false || exit 1
+cd ..
+
+echo
+echo "Test 2: qxl.test2/qxl.test2A, latest version"
+rm -rf myapp
+qx create myapp -I
+cd myapp
+qx contrib install qooxdoo/qxl.test2/qxl.test2A
+LIST=$(qx contrib list --short --noheaders --installed --all)
+echo "$LIST"
+COUNTLINES=$(echo "$LIST" | wc -l | tr -d ' ')
+[ "$COUNTLINES" == "4" ] || (echo "Installing dependencies failed" || exit 1)
+qx compile --feedback=false || exit 1
+cd ..
+
+echo
+echo "Test 3: qxl.test1@v1.0.2 version"
+rm -rf myapp
+qx create myapp -I
+cd myapp
+qx contrib install qooxdoo/qxl.test1@v1.0.2
+LIST=$(qx contrib list --short --noheaders --installed --all)
+echo "$LIST"
+EXPECTED="\
+qooxdoo/qxl.test1              v1.0.2   v1.0.2   v1.0.2
+qooxdoo/qxl.test2/qxl.test2C   v1.0.2   v1.0.2   v1.0.2
+qooxdoo/qxl.test2/qxl.test2D   v1.0.2   v1.0.2   v1.0.2"
+[ "$EXPECTED" == "$LIST" ] || (echo "Installing dependencies failed" || exit 1)
+qx compile --feedback=false || exit 1
+cd ..
+
+echo
+echo "Test 4: qxl.test1@e27ecf811667c1b3bc5dc023d806e74a9328a26c"
+rm -rf myapp
+qx create myapp -I
+cd myapp
+qx contrib install qooxdoo/qxl.test1@e27ecf811667c1b3bc5dc023d806e74a9328a26c
+LIST=$(qx contrib list --short --noheaders --installed --all)
+echo "$LIST"
+EXPECTED="\
+qooxdoo/qxl.test1              e27ecf811667c1b3bc5dc023d806e74a9328a26c   v1.0.2   v1.0.2
+qooxdoo/qxl.test2/qxl.test2C   v1.0.2                                     v1.0.2   v1.0.2
+qooxdoo/qxl.test2/qxl.test2D   v1.0.2                                     v1.0.2   v1.0.2"
+[ "$EXPECTED" == "$LIST" ] || (echo "Installing dependencies failed" || exit 1)
+qx compile --feedback=false || exit 1
+cd ..

--- a/test/test.linux.sh
+++ b/test/test.linux.sh
@@ -7,6 +7,8 @@ cd test
 node test-deps.js
 cd ..
 
+bash test/bash/test-dependency-management.sh || exit $?
+
 rm -rf myapp
 # test create app
 qx create myapp -I --type server -v || exit $?


### PR DESCRIPTION
This should make the compiler do what we discussed in #353: Install dependencies of 
dependencies in `contrib.json`, but not in `Manifest.json`, and make it possible to 
delete `contrib.json` and recreate it from the dependency information in `Manifest.json`.

PLEASE TEST THIS BRANCH/PR WITH YOUR APPS FIRST before merging, please. 