### PR TITLE
Config file versioning

### DIFF
--- a/lib/qx/tool/cli/Cli.js
+++ b/lib/qx/tool/cli/Cli.js
@@ -17,6 +17,7 @@
 ************************************************************************ */
 
 require("qooxdoo");
+require("./ConfigSchemas");
 
 /**
  * Entry point for the CLI

--- a/lib/qx/tool/cli/ConfigSchemas.js
+++ b/lib/qx/tool/cli/ConfigSchemas.js
@@ -1,0 +1,42 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2019 The qooxdoo developers
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project's top-level directory for details.
+
+   Authors:
+     * Christian Boulanger (info@bibliograph.org, @cboulanger)
+
+************************************************************************ */
+
+/**
+ * This class contains constants used for locating and versioning
+ * of the different configuration files
+ */
+qx.Class.define("qx.tool.cli.ConfigSchemas", {
+
+  statics: {
+
+    library: {
+      filename: "Manifest.json",
+      schema: "https://qooxdoo.org/schema/Manifest.json/v2"
+    },
+
+    compiler: {
+      filename: "compile.json",
+      schema: "https://qooxdoo.org/schema/compile.json/v1"
+    },
+
+    lockfile: {
+      filename: "contrib.json",
+      version: "2"
+    }
+  }
+});

--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -619,8 +619,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
      * @param {qx.tool.compiler.makers.Maker} maker
      *    The maker object
      * @param {Object|*} contribs
-     *    If given, an object mapping library uris to
-     *    {@link qx.tool.compiler.app.Library} objects
+     *    If given, an object mapping library uris to library paths
      * @return {Promise<Array>} Array of error messages
      * @private
      */

--- a/lib/qx/tool/cli/commands/Compile.js
+++ b/lib/qx/tool/cli/commands/Compile.js
@@ -165,6 +165,11 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
             describe: "Whether bundling is enabled",
             type: "boolean",
             default: true
+          },
+          "force": {
+            describe: "Override warnings",
+            type: "boolean",
+            default: false
           }
         },
         handler: function(argv) {

--- a/lib/qx/tool/cli/commands/Contrib.js
+++ b/lib/qx/tool/cli/commands/Contrib.js
@@ -69,7 +69,15 @@ qx.Class.define("qx.tool.cli.commands.Contrib", {
      * @return {String}
      */
     getContribFileName: function() {
-      return path.join(process.cwd(), "contrib.json");
+      return path.join(process.cwd(), qx.tool.cli.ConfigSchemas.lockfile.filename);
+    },
+
+    /**
+     * Deletes contrib.json
+     * @return {Promise<void>}
+     */
+    async deleteContribData() {
+      await fs.unlinkAsync(this.getContribFileName());
     },
 
     /**
@@ -79,7 +87,10 @@ qx.Class.define("qx.tool.cli.commands.Contrib", {
     getContribData: async function() {
       let contrib_json_path = this.getContribFileName();
       if (!await fs.existsAsync(contrib_json_path)) {
-        return {libraries : []};
+        return {
+          version: qx.tool.cli.ConfigSchemas.lockfile.version,
+          libraries: []
+        };
       }
       return qx.tool.compiler.utils.Json.loadJsonAsync(contrib_json_path);
     },

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -74,17 +74,15 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
             await fs.copyFileAsync(filepath, backup);
             await installer.deleteContribData();
             for (let lib of contribConfig.libraries) {
-              if (!installer.isInstalled(lib.uri)) {
-                await installer.install(lib.uri, lib.repo_tag);
-              }
+              await installer.install(lib.uri, lib.repo_tag);
             }
-            contribConfig = installer.getContribData();
+            contribConfig = await installer.getContribData();
             console.info(`A backup of ${lockfile} has been saved to ${backup}.`);
           } else {
             throw new qx.tool.cli.Utils.UserError(
               `*** Warning ***\n` +
               `The schema of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' to delete and regenerate it and then compile again.\n` +
-              `You might have to re-apply modifications to '${lockfile}'.`
+              `You might have to re-apply manual modifications to '${lockfile}'.`
             );
           }
         }

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -81,7 +81,7 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
           } else {
             throw new qx.tool.cli.Utils.UserError(
               `*** Warning ***\n` +
-              `The schema of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' to delete and regenerate it and then compile again.\n` +
+              `The schema of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' to delete and regenerate it.\n` +
               `You might have to re-apply manual modifications to '${lockfile}'.`
             );
           }

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -65,7 +65,7 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
             contrib.deleteContribData();
             contribConfig = contrib.getContribData();
           } else {
-            throw new qx.tool.cli.Utils.UserError(`The version of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' and then 'qx compile' again to regenerate it. Warning: this might break your app and you might have to re-apply modifications. You have been warne. If in doubt, use an earlier compiler version.`);
+            throw new qx.tool.cli.Utils.UserError(`The version of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' and then 'qx compile' again to regenerate it. Warning: this might break your app and you might have to re-apply modifications. You have been warned. If in doubt, use an earlier compiler version.`);
           }
         }
       }

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -67,11 +67,18 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
             contrib.deleteContribData();
             contribConfig = contrib.getContribData();
           } else {
+            let msg;
+            switch (contribConfig.version) {
+              case undefined:
+                msg = `*** Warning ***\n`+
+                  `This might break your app. You might have to reinstall missing libraries and re-apply modifications to '${lockfile}'. ` +
+                  `If in doubt, use an earlier compiler version. `;
+                break;
+              default:
+                msg = "";
+            }
             throw new qx.tool.cli.Utils.UserError(
-              `The version of '${lockfile}' has changed.\n` +
-              `Execute 'qx clean && qx compile --force' and then 'qx compile' again to regenerate it.\n` +
-              `Warning: this might break your app and you might have to re-apply modifications to '${lockfile}'.\n` +
-              `You have been warned. If in doubt, use an earlier compiler version.`
+              `The schema of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' to delete and regenerate it and then compile again.\n` + msg
             );
           }
         }

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -76,6 +76,8 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
             for (let lib of contribConfig.libraries) {
               if (!await installer.isInstalled(lib.uri, lib.repo_tag)) {
                 await installer.install(lib.uri, lib.repo_tag);
+              } else if (this.argv.verbose) {
+                console.info(`>>> ${lib.uri}@${lib.repo_tag} is already installed.`);
               }
             }
             contribConfig = await installer.getContribData();

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -67,7 +67,12 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
             contrib.deleteContribData();
             contribConfig = contrib.getContribData();
           } else {
-            throw new qx.tool.cli.Utils.UserError(`The version of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' and then 'qx compile' again to regenerate it. Warning: this might break your app and you might have to re-apply modifications. You have been warned. If in doubt, use an earlier compiler version.`);
+            throw new qx.tool.cli.Utils.UserError(
+              `The version of '${lockfile}' has changed.\n` +
+              `Execute 'qx clean && qx compile --force' and then 'qx compile' again to regenerate it.\n` +
+              `Warning: this might break your app and you might have to re-apply modifications to '${lockfile}'.\n` +
+              `You have been warned. If in doubt, use an earlier compiler version.`
+            );
           }
         }
       }

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -48,7 +48,9 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
     parse: async function() {
       var parsedArgs = await this.__parseImpl();
       var config = {};
-      var contribConfig = {};
+      var contribConfig = {
+        version: qx.tool.cli.ConfigSchemas.lockfile.version
+      };
 
       if (parsedArgs.config) {
         config = await this.__loadJson(parsedArgs.config);
@@ -90,7 +92,7 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
         var defaultTarget = parsedArgs.target||config.defaultTarget;
         if (defaultTarget) {
           for (var i = 0; i < config.targets.length; i++) {
-            if (config.targets[i].type == defaultTarget) {
+            if (config.targets[i].type === defaultTarget) {
               config.target = config.targets[i];
               break;
             }
@@ -180,16 +182,17 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
       if (!config.serve) {
         config.serve = {};
       }
-      if (this.isExplicitArg("listen-port"))
+      if (this.isExplicitArg("listen-port")) {
         config.serve.listenPort = this.argv.listenPort;
-      else
-        config.serve.listenPort = config.serve.listenPort||this.argv.listenPort;
+      } else {
+        config.serve.listenPort = config.serve.listenPort || this.argv.listenPort;
+      }
     },
 
     /**
      * Parses the command line, and produces a normalised configuration;
      *
-     * @return {Obj}
+     * @return {Object}
      */
     __parseImpl: async function() {
       let apps = [];

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -63,22 +63,28 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
         }
         if (contribConfig.version !== qx.tool.cli.ConfigSchemas.lockfile.version) {
           if (this.argv.force) {
-            const contrib = new qx.tool.cli.commands.Contrib(this.argv);
-            contrib.deleteContribData();
-            contribConfig = contrib.getContribData();
-          } else {
-            let msg;
-            switch (contribConfig.version) {
-              case undefined:
-                msg = `*** Warning ***\n`+
-                  `This might break your app. You might have to reinstall missing libraries and re-apply modifications to '${lockfile}'. ` +
-                  `If in doubt, use an earlier compiler version. `;
-                break;
-              default:
-                msg = "";
+            let config = {
+              verbose: this.argv.verbose,
+              quite: this.argv.quiet,
+              save: false
+            };
+            const installer = new qx.tool.cli.commands.contrib.Install(config);
+            let filepath = installer.getContribFileName();
+            let backup = filepath + ".old";
+            await fs.copyFileAsync(filepath, backup);
+            await installer.deleteContribData();
+            for (let lib of contribConfig.libraries) {
+              if (!installer.isInstalled(lib.uri)) {
+                await installer.install(lib.uri, lib.repo_tag);
+              }
             }
+            contribConfig = installer.getContribData();
+            console.info(`A backup of ${lockfile} has been saved to ${backup}.`);
+          } else {
             throw new qx.tool.cli.Utils.UserError(
-              `The schema of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' to delete and regenerate it and then compile again.\n` + msg
+              `*** Warning ***\n` +
+              `The schema of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' to delete and regenerate it and then compile again.\n` +
+              `You might have to re-apply modifications to '${lockfile}'.`
             );
           }
         }

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -74,7 +74,9 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
             await fs.copyFileAsync(filepath, backup);
             await installer.deleteContribData();
             for (let lib of contribConfig.libraries) {
-              await installer.install(lib.uri, lib.repo_tag);
+              if (!await installer.isInstalled(lib.uri, lib.repo_tag)) {
+                await installer.install(lib.uri, lib.repo_tag);
+              }
             }
             contribConfig = await installer.getContribData();
             console.info(`A backup of ${lockfile} has been saved to ${backup}.`);

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -52,11 +52,21 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
 
       if (parsedArgs.config) {
         config = await this.__loadJson(parsedArgs.config);
+        let lockfile = qx.tool.cli.ConfigSchemas.lockfile.filename;
         try {
-          var name = path.join(path.dirname(parsedArgs.config), "contrib.json");
+          var name = path.join(path.dirname(parsedArgs.config), lockfile);
           contribConfig = await this.__loadJson(name);
         } catch (ex) {
           // Nothing
+        }
+        if (contribConfig.version !== qx.tool.cli.ConfigSchemas.lockfile.version) {
+          if (this.argv.force) {
+            const contrib = new qx.tool.cli.commands.Contrib(this.argv);
+            contrib.deleteContribData();
+            contribConfig = contrib.getContribData();
+          } else {
+            throw new qx.tool.cli.Utils.UserError(`The version of '${lockfile}' has changed. Execute 'qx clean && qx compile --force' and then 'qx compile' again to regenerate it. Warning: this might break your app and you might have to re-apply modifications. You have been warne. If in doubt, use an earlier compiler version.`);
+          }
         }
       }
       this._mergeArguments(parsedArgs, config, contribConfig);
@@ -166,7 +176,7 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
           config.contribs[library.uri] = library.path;
         });
       }
-      
+
       if (!config.serve) {
         config.serve = {};
       }

--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -135,7 +135,6 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
         [uri, id] = uri.split(/@/);
       }
 
-
       // install library/libraries
       if (!id || (qx.lang.Type.isString(id) && id.startsWith("v"))) {
         // we use the latest or a given release
@@ -410,7 +409,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
               if (!version) {
                 throw new qx.tool.cli.Utils.UserError(`No satisfying version found for ${lib_uri}@${lib_version}!`);
               }
-              if (!this.isInstalled(lib_uri, version)) {
+              if (!await this.isInstalled(lib_uri, version)) {
                 await this.__installFromRelease(lib_uri, `v${version}`, false);
                 break;
               }
@@ -420,7 +419,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
               break;
             }
             // treat version info as tree-ish identifier
-            if (!this.isInstalled(lib_uri, lib_version)) {
+            if (!await this.isInstalled(lib_uri, lib_version)) {
               try {
                 await this.__installFromTree(lib_uri, lib_version, false);
                 break;

--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -93,6 +93,16 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
       await this.process();
     },
 
+    /**
+     * API method to check if a library has been installed
+     * @param {String} library_uri
+     * @param {String} release_tag
+     * @return {Promise<Boolean>}
+     */
+    async isInstalled(library_uri, release_tag) {
+      let contribData = await this.getContribData();
+      return contribData.libraries.some(lib => lib.uri === library_uri && (release_tag === undefined || release_tag === lib.repo_tag));
+    },
 
     /**
      * Installs a contrib library

--- a/lib/qx/tool/cli/commands/contrib/Install.js
+++ b/lib/qx/tool/cli/commands/contrib/Install.js
@@ -89,7 +89,11 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
      * @return {Promise<void>}
      */
     async install(library_uri, release_tag) {
-      this.argv["contrib_uri@release_tag"]= library_uri + (release_tag?"@"+release_tag:"");
+      let installee = library_uri + (release_tag?"@"+release_tag:"");
+      if (this.argv.verbose) {
+        console.info(`>>> To be installed: ${installee}`);
+      }
+      this.argv["contrib_uri@release_tag"]= installee;
       await this.process();
     },
 
@@ -113,6 +117,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
 
       // if no library uri has been passed install from contrib.json or Manifest.json
       if (!this.argv["contrib_uri@release_tag"]) {
+
         if (this.__data.libraries.length) {
           await this.__loadFromContribJson();
         } else {
@@ -184,9 +189,17 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
      * @private
      */
     async __saveConfigData() {
-      await qx.tool.compiler.utils.Json.saveJsonAsync(this.getContribFileName(), this.__data);
+      let lockfile = this.getContribFileName();
+      await qx.tool.compiler.utils.Json.saveJsonAsync(lockfile, this.__data);
+      if (this.argv.verbose) {
+        console.info(`>>> Saved library data to ${lockfile}`);
+      }
       if (this.argv.save) {
-        await qx.tool.compiler.utils.Json.saveJsonAsync("Manifest.json", this.__manifest);
+        let manifest_file = qx.tool.cli.ConfigSchemas.library.filename;
+        await qx.tool.compiler.utils.Json.saveJsonAsync(manifest_file, this.__manifest);
+        if (this.argv.verbose) {
+          console.info(`>>> Saved dependency data to ${manifest_file}`);
+        }
       }
     },
 
@@ -356,9 +369,16 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
      * @return {Promise<Boolean>} Wether any libraries were installed
      */
     __installDependenciesFromPath: async function(downloadPath) {
-      let manifest = await qx.tool.compiler.utils.Json.loadJsonAsync(path.join(downloadPath, "Manifest.json"));
+      let manifest_file = path.join(downloadPath, qx.tool.cli.ConfigSchemas.library.filename);
+      let manifest = await qx.tool.compiler.utils.Json.loadJsonAsync(manifest_file);
       if (!manifest.requires) {
+        if (this.argv.verbose) {
+          console.info(`>>> ${manifest_file} does not contain library dependencies.`);
+        }
         return false;
+      }
+      if (this.argv.verbose) {
+        console.info(`>>> Installing libraries from ${manifest_file}.`);
       }
       return this.__installDependenciesFromManifest(manifest);
     },
@@ -390,15 +410,26 @@ qx.Class.define("qx.tool.cli.commands.contrib.Install", {
               if (!version) {
                 throw new qx.tool.cli.Utils.UserError(`No satisfying version found for ${lib_uri}@${lib_version}!`);
               }
-              await this.__installFromRelease(lib_uri, `v${version}`, false);
+              if (!this.isInstalled(lib_uri, version)) {
+                await this.__installFromRelease(lib_uri, `v${version}`, false);
+                break;
+              }
+              if (this.argv.verbose) {
+                console.info(`>>> ${lib_uri}@${version} is already installed.`);
+              }
               break;
             }
             // treat version info as tree-ish identifier
-            try {
-              await this.__installFromTree(lib_uri, lib_version, false);
-              break;
-            } catch (e) {
-              throw new qx.tool.cli.Utils.UserError(`Could not install ${lib_uri}@${lib_version}: ${e.message}`);
+            if (!this.isInstalled(lib_uri, lib_version)) {
+              try {
+                await this.__installFromTree(lib_uri, lib_version, false);
+                break;
+              } catch (e) {
+                throw new qx.tool.cli.Utils.UserError(`Could not install ${lib_uri}@${lib_version}: ${e.message}`);
+              }
+            }
+            if (this.argv.verbose) {
+              console.info(`>>> ${lib_uri}@${lib_version} is already installed.`);
             }
           }
         }

--- a/test/bash/test-dependency-management.sh
+++ b/test/bash/test-dependency-management.sh
@@ -5,12 +5,12 @@ echo "Test 1: qxl.test1, latest version"
 [[ -d myapp ]] && rm -rf myapp
 qx create myapp -I
 cd myapp
-qx contrib install qooxdoo/qxl.test1
+qx contrib install qooxdoo/qxl.test1 --verbose
 LIST=$(qx contrib list --short --noheaders --installed --all)
 echo "$LIST"
 COUNTLINES=$(echo "$LIST" | wc -l | tr -d ' ')
-[ "$COUNTLINES" == "3" ] || (echo "Installing dependencies failed" || exit 1)
-qx compile --feedback=false || exit 1
+if [ "$COUNTLINES" != "3" ]; then echo "Installing dependencies failed"; exit 1; fi
+qx compile --feedback=false --warnAsError || exit 1
 cd ..
 
 echo
@@ -18,12 +18,12 @@ echo "Test 2: qxl.test2/qxl.test2A, latest version"
 rm -rf myapp
 qx create myapp -I
 cd myapp
-qx contrib install qooxdoo/qxl.test2/qxl.test2A
+qx contrib install qooxdoo/qxl.test2/qxl.test2A --verbose
 LIST=$(qx contrib list --short --noheaders --installed --all)
 echo "$LIST"
 COUNTLINES=$(echo "$LIST" | wc -l | tr -d ' ')
-[ "$COUNTLINES" == "4" ] || (echo "Installing dependencies failed" || exit 1)
-qx compile --feedback=false || exit 1
+if [ "$COUNTLINES" != "4" ]; then echo "Installing dependencies failed"; exit 1; fi
+qx compile --feedback=false --warnAsError || exit 1
 cd ..
 
 echo
@@ -31,15 +31,15 @@ echo "Test 3: qxl.test1@v1.0.2 version"
 rm -rf myapp
 qx create myapp -I
 cd myapp
-qx contrib install qooxdoo/qxl.test1@v1.0.2
+qx contrib install qooxdoo/qxl.test1@v1.0.2 --verbose
 LIST=$(qx contrib list --short --noheaders --installed --all)
 echo "$LIST"
 EXPECTED="\
 qooxdoo/qxl.test1              v1.0.2   v1.0.2   v1.0.2
 qooxdoo/qxl.test2/qxl.test2C   v1.0.2   v1.0.2   v1.0.2
 qooxdoo/qxl.test2/qxl.test2D   v1.0.2   v1.0.2   v1.0.2"
-[ "$EXPECTED" == "$LIST" ] || (echo "Installing dependencies failed" || exit 1)
-qx compile --feedback=false || exit 1
+if [ "$EXPECTED" != "$LIST" ]; then echo "Installing dependencies failed"; exit 1; fi
+qx compile --feedback=false --warnAsError || exit 1
 cd ..
 
 echo
@@ -47,13 +47,13 @@ echo "Test 4: qxl.test1@e27ecf811667c1b3bc5dc023d806e74a9328a26c"
 rm -rf myapp
 qx create myapp -I
 cd myapp
-qx contrib install qooxdoo/qxl.test1@e27ecf811667c1b3bc5dc023d806e74a9328a26c
+qx contrib install qooxdoo/qxl.test1@e27ecf811667c1b3bc5dc023d806e74a9328a26c --verbose
 LIST=$(qx contrib list --short --noheaders --installed --all)
 echo "$LIST"
 EXPECTED="\
 qooxdoo/qxl.test1              e27ecf811667c1b3bc5dc023d806e74a9328a26c   v1.0.2   v1.0.2
 qooxdoo/qxl.test2/qxl.test2C   v1.0.2                                     v1.0.2   v1.0.2
 qooxdoo/qxl.test2/qxl.test2D   v1.0.2                                     v1.0.2   v1.0.2"
-[ "$EXPECTED" == "$LIST" ] || (echo "Installing dependencies failed" || exit 1)
-qx compile --feedback=false || exit 1
+if [ "$EXPECTED" != "$LIST" ]; then echo "Installing dependencies failed"; exit 1; fi
+qx compile --feedback=false --warnAsError || exit 1
 cd ..

--- a/test/test.linux.sh
+++ b/test/test.linux.sh
@@ -7,6 +7,7 @@ cd test
 node test-deps.js
 cd ..
 
+qx contrib update || exit $?
 bash test/bash/test-dependency-management.sh || exit $?
 
 rm -rf myapp


### PR DESCRIPTION
This is necessary because the last commit introduced changes to the
path of contribs in contrib.json. This PR adds a more general framework
for the future versioning of all configuration files and alerts the user
that manual intervention might be neccessary. 