### PR TITLE
Add --releases-only and --dryrun

### DIFF
--- a/lib/qx/tool/cli/commands/contrib/Publish.js
+++ b/lib/qx/tool/cli/commands/contrib/Publish.js
@@ -64,6 +64,7 @@ qx.Class.define("qx.tool.cli.commands.contrib.Publish", {
             describe: "Set commit/release message"
           },
           "dryrun":{
+            alias: "d",
             describe: "Show result only, do not publish to GitHub"
           },
           "verbose": {

--- a/lib/qx/tool/cli/commands/contrib/Upgrade.js
+++ b/lib/qx/tool/cli/commands/contrib/Upgrade.js
@@ -62,6 +62,9 @@ qx.Class.define("qx.tool.cli.commands.contrib.Upgrade", {
   members: {
     async process() {
       await (new qx.tool.cli.commands.contrib.Update({quiet:this.argv.quiet, verbose:this.argv.verbose})).process();
+      if (!this.argv.quiet) {
+        console.info("Upgrading project dependencies to their latest available releases...");
+      }
       let data = await this.getContribData();
       let found = false;
       const installer = new qx.tool.cli.commands.contrib.Install({
@@ -78,14 +81,16 @@ qx.Class.define("qx.tool.cli.commands.contrib.Upgrade", {
           continue;
         }
         found = true;
-        if (this.argv.releasesOnly && (!library.repo_tag || !library.repo_tag.beginsWith("v"))) {
-          if (this.argv.verbose) {
-            console.info(`Skipping ${library.library_name} (${library.uri}) since it is not a release.`);
+        if (this.argv.releasesOnly && (!qx.lang.Type.isString(library.repo_tag) || !library.repo_tag.startsWith("v"))) {
+          if (!this.argv.quiet) {
+            console.info(`Skipping ${library.library_name} (${library.uri}@${library.repo_tag}) since it is not a release.`);
           }
+          continue;
         }
         try {
           if (this.argv.dryrun) {
-            console.info(`Dry run. Not upgrading ${library.library_name} (${library.uri}.`);
+            console.info(`Dry run. Not upgrading ${library.library_name} (${library.uri}@${library.repo_tag}).`);
+            continue;
           }
           await installer.install(library.uri);
         } catch (e) {

--- a/lib/qx/tool/cli/commands/contrib/Upgrade.js
+++ b/lib/qx/tool/cli/commands/contrib/Upgrade.js
@@ -37,6 +37,14 @@ qx.Class.define("qx.tool.cli.commands.contrib.Upgrade", {
           "verbose": {
             alias: "v",
             describe: "Verbose logging"
+          },
+          "releases-only": {
+            alias: "r",
+            describe: "Upgrade regular releases only"
+          },
+          "dryrun":{
+            alias: "d",
+            describe: "Show result only, do not actually upgrade"
           }
         },
         handler: function (argv) {
@@ -70,7 +78,15 @@ qx.Class.define("qx.tool.cli.commands.contrib.Upgrade", {
           continue;
         }
         found = true;
+        if (this.argv.releasesOnly && (!library.repo_tag || !library.repo_tag.beginsWith("v"))) {
+          if (this.argv.verbose) {
+            console.info(`Skipping ${library.library_name} (${library.uri}) since it is not a release.`);
+          }
+        }
         try {
+          if (this.argv.dryrun) {
+            console.info(`Dry run. Not upgrading ${library.library_name} (${library.uri}.`);
+          }
           await installer.install(library.uri);
         } catch (e) {
           console.warn(e.message);

--- a/test/bash/test-dependency-management.sh
+++ b/test/bash/test-dependency-management.sh
@@ -27,7 +27,7 @@ qx compile --feedback=false --warnAsError || exit 1
 cd ..
 
 echo
-echo "Test 3: qxl.test1@v1.0.2 version"
+echo "Test 3: qxl.test1@v1.0.2 version, then upgrade"
 rm -rf myapp
 qx create myapp -I
 cd myapp
@@ -43,6 +43,16 @@ echo "$LIST"
 COUNTLINES=$(echo "$LIST" | wc -l | tr -d ' ')
 if [ "$COUNTLINES" != "3" ]; then echo "Installing dependencies failed"; exit 1; fi
 qx compile --feedback=false --warnAsError || exit 1
+
+qx contrib upgrade
+LIST=$(qx contrib list --short --noheaders --installed --all)
+echo "$LIST"
+# Will be reimplemented later when output stabilizes
+#EXPECTED="\
+#qooxdoo/qxl.test1                 v1.0.3   v1.0.3   v1.0.3
+#qooxdoo/qxl.test2/qxl.test2C      v1.0.2   v1.0.2   v1.0.2
+#qooxdoo/qxl.test2/qxl.test2D      v1.0.2   v1.0.2   v1.0.2"
+#if [ "$EXPECTED" != "$LIST" ]; then echo "Installing dependencies failed"; exit 1; fi
 cd ..
 
 echo
@@ -63,3 +73,4 @@ COUNTLINES=$(echo "$LIST" | wc -l | tr -d ' ')
 if [ "$COUNTLINES" != "3" ]; then echo "Installing dependencies failed"; exit 1; fi
 qx compile --feedback=false --warnAsError || exit 1
 cd ..
+


### PR DESCRIPTION
This adds an option to upgrade only the libraries from a released package, 
and leave all others alone. Also, a new dryrun option allows to simulate
an upgrade and see what it would entail. This could be improved by adding
a dryrun option to Install.js