### PR TITLE
fixes a bug where `qx serve` ignored bundling

### DIFF
--- a/lib/qx/tool/cli/commands/Serve.js
+++ b/lib/qx/tool/cli/commands/Serve.js
@@ -114,6 +114,11 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
             describe: "Write library information to the script, for reflection",
             type: "boolean",
             default: true
+          },
+          "bundling": {
+            describe: "Whether bundling is enabled",
+            type: "boolean",
+            default: true
           }
         },
         handler   : function(argv) {


### PR DESCRIPTION
fixes a bug reported by @voger on gitter