### PR TITLE
add createElement stub

### DIFF
--- a/lib/qx/tool/compiler/app/loader-server.tmpl.js
+++ b/lib/qx/tool/compiler/app/loader-server.tmpl.js
@@ -35,6 +35,9 @@
           initCustomEvent: function() {}
         };
       },
+      createElement: function () {
+		  return {}
+	  },
       addListener: function() {},
       removeListener: function() {},
       documentElement: {


### PR DESCRIPTION
To use @qooxdoo/framework in qxcompiler we need this patch as a first step. @qooxdoo/Framework is not running if not compiled with a createElement stub