### PR TITLE
Add support for class files ending in .ts

### DIFF
--- a/lib/qx/tool/compiler/ClassFile.js
+++ b/lib/qx/tool/compiler/ClassFile.js
@@ -291,7 +291,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
               filename: t.getSourcePath(),
               sourceMaps: true,
               "presets": [
-                [ require.resolve("@babel/preset-env"), options]
+                [ require.resolve("@babel/preset-env"), options],
+                [ require.resolve("@babel/preset-typescript")]
               ],
               plugins: [
                 t._babelClassPlugin()
@@ -2015,7 +2016,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
      * @returns {String}
      */
     getSourcePath: function(library, className) {
-      return pathModule.join(library.getRootDir(), library.getSourcePath(), className.replace(/\./g, pathModule.sep) + ".js");
+      return pathModule.join(library.getRootDir(), library.getSourcePath(), className.replace(/\./g, pathModule.sep) + library.getSourceFileExtension(className));
     },
 
     /**

--- a/lib/qx/tool/compiler/app/Library.js
+++ b/lib/qx/tool/compiler/app/Library.js
@@ -38,6 +38,7 @@ qx.Class.define("qx.tool.compiler.app.Library", {
   construct: function() {
     this.base(arguments);
     this.__knownSymbols = {};
+    this.__sourceFileExtensions = {};
   },
 
   properties: {
@@ -118,6 +119,7 @@ qx.Class.define("qx.tool.compiler.app.Library", {
 
   members: {
     __knownSymbols: null,
+    __sourceFileExtensions: null,
 
     /**
      * Transform for rootDir; converts it to an absolute path
@@ -274,8 +276,9 @@ qx.Class.define("qx.tool.compiler.app.Library", {
                     cb();
                     return;
                   }
-                  if (extension == ".js") {
+                  if (extension == ".js" || extension == ".ts") {
                     t.__knownSymbols[className] = "class";
+                    t.__sourceFileExtensions[className] = extension;
                     classes.push(className);
                   } else {
                     t.__knownSymbols[filename] = "resource";
@@ -340,6 +343,16 @@ qx.Class.define("qx.tool.compiler.app.Library", {
      */
     getKnownSymbols: function() {
       return this.__knownSymbols;
+    },
+
+    /**
+     * Returns the original extension of the class file that implemented the
+     * given class name.
+     *
+     * @param {String} className
+     */
+    getSourceFileExtension: function(className) {
+      return this.__sourceFileExtensions[className];
     },
 
     /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -322,6 +322,14 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz",
+      "integrity": "sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.2.0.tgz",
@@ -586,6 +594,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.4.tgz",
+      "integrity": "sha512-rwDvjaMTx09WC0rXGBRlYSSkEHOKRrecY6hEr3SVIPKII8DVWXtapNAfAyMC0dovuO+zYArcAuKeu3q9DNRfzA==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-typescript": "^7.2.0"
+      }
+    },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
@@ -658,6 +675,15 @@
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz",
+      "integrity": "sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-transform-typescript": "^7.3.2"
       }
     },
     "@babel/template": {
@@ -2335,7 +2361,7 @@
       "resolved": "https://registry.npmjs.org/es6-promisify-all/-/es6-promisify-all-0.1.0.tgz",
       "integrity": "sha1-RCuaHqjgCw/VsodyVVBY/eXp8gc=",
       "requires": {
-        "es6-promisify": "github:pgaubatz/es6-promisify"
+        "es6-promisify": "github:pgaubatz/es6-promisify#3d8966c58bace65f762b7335e99e3f43b987bce4"
       },
       "dependencies": {
         "es6-promise": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/plugin-transform-block-scoping": "^7.4.0",
     "@babel/polyfill": "^7.4.0",
     "@babel/preset-env": "^7.4.0",
+    "@babel/preset-typescript": "^7.3.3",
     "@babel/traverse": "^7.4.0",
     "@babel/types": "^7.4.0",
     "@octokit/rest": "^15.18.0",


### PR DESCRIPTION
To make use of TypeScript in an existing qooxdoo project, especially
when migrating incrementally, it would be useful to allow .ts files
to be transpiled by the qooxdoo compiler.

This does not require much voodoo since babel 7 has presets that allow
stripping of typescript type annotations et al. More details can be
found for example in the announcement post here:
https://devblogs.microsoft.com/typescript/typescript-and-babel-7/

What needs to change then is:
- the compiler being able to recognize .ts files in the same way as
  .js files and reconstruct the filename including extension
- the babel step needs to use the @babel/preset-typescript preset

This allows users to rename their .js files to .ts and make use of the
languages features, especially type annotations. An IDE like Visual
Studio Code will properly type check those files. The typescript
compiler can be used separately to type check the .ts files during
build steps.