### PR TITLE
Typescript: Keep method documentation and add getInstance method to singletons

### DIFF
--- a/lib/qx/tool/compiler/ClassFile.js
+++ b/lib/qx/tool/compiler/ClassFile.js
@@ -861,7 +861,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
               t._requireClass(t.__classMeta.superClass, { location: path.node.loc });
             }
           } else if (keyName == "type") {
-            var type = collapseMemberExpression(prop.value);
+            var type = prop.value.value;
             t.__classMeta.isAbstract = type === "abstract";
             t.__classMeta.isStatic = type === "static";
             t.__classMeta.isSingleton = type === "singleton";

--- a/lib/qx/tool/compiler/targets/TypeScriptWriter.js
+++ b/lib/qx/tool/compiler/targets/TypeScriptWriter.js
@@ -364,6 +364,19 @@ qx.Class.define("qx.tool.compiler.targets.TypeScriptWriter", {
       if (meta.type == "class") {
         this.writeConstructor(meta.construct);
       }
+
+      if (meta.isSingleton) {
+        this.writeMethods({
+          getInstance: {
+            type: 'function',
+            access: 'public',
+            jsdoc: {
+              "@return": [{ type: meta.className }]
+            }
+          }
+        }, meta, true);
+      }
+
       this.writeMethods(meta.statics, meta, true);
       this.writeMethods(meta.members, meta);
       this.write("\n  }\n");

--- a/lib/qx/tool/compiler/targets/TypeScriptWriter.js
+++ b/lib/qx/tool/compiler/targets/TypeScriptWriter.js
@@ -253,6 +253,17 @@ qx.Class.define("qx.tool.compiler.targets.TypeScriptWriter", {
           if (comment) {
             comment = " // " + comment;
           }
+
+          let hasDescription = methodMeta.jsdoc && methodMeta.jsdoc["@description"] && methodMeta.jsdoc["@description"][0];
+
+          if (hasDescription) {
+            this.write(this.__indent + "/**\n");
+            methodMeta.jsdoc["@description"][0].body.split("\n").forEach(line => {
+              this.write(this.__indent + " * " + line + "\n");
+            });
+            this.write(this.__indent + " */\n");
+          }
+
           this.write(this.__indent + (hideMethod ? "// " : "") + decl + ";" + comment + "\n");
         }
       }


### PR DESCRIPTION
I'm currently on a quest to migrate some of our code-base to typescript and there are some things blocking a smooth transition. I'm not sure how your contribution guidelines for these kind of things are, so I'm just PRing these as I go. There will probably be more PRs of this type in the future, if that is in your interested.

This particular PR takes care of classes of type singleton missing the type definition for the getInstance method. This brought a small bug to light (regarding isSingleton on class meta data being wrong) that seemingly never caused any issues. That is fixed and is being used by the TypeScriptWriter now.

The other commit in this PR ensures that the method documentation isn't lost when generating the type definition file.