### PR TITLE
This change exposes the global `qx` and `process` objects

### DIFF
--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -285,6 +285,8 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
         let p = new Promise((resolve, reject) => {
           const contextData = {
               require: require,
+              qx: qx,
+              process: process,
               compiler: {
                 command: this,
                 inputData,


### PR DESCRIPTION
the `qx` object is exposed so that the `compile.js` has the exact qooxdoo the compiler uses, and so that it has the `qx.tool.*` classes available to it.  The `process` object is normally available to node apps.

