### PR TITLE
Switches to using `require` instead of `require('vm').Script` to load compile.js

### DIFF
--- a/docs/configuration/compile.md
+++ b/docs/configuration/compile.md
@@ -466,7 +466,7 @@ module.exports = function(compiler) {
 ### How to add sass call for mobile projects:
 
 ```javascript
-async function compile(data, callback) {
+module.exports = async function compile(compiler) {
   /**
  * Adds sass support for current project.
  * Needed for qx.mobile projects.
@@ -475,12 +475,13 @@ async function compile(data, callback) {
  *    - add dependency to project package.json: "runscript": "^1.3.0"
  *    - run npm install in project dir.
  *  
- * @param {*} data       : config data from compile.json
+ * @param {*} data       : compiler interface
  * @param {*} callback   : callback for qxcli.  
  */
   debugger;
   const runscript = require('runscript');
   const util = require('util');
+  let data = compiler.inputData;
   runScript = async function (cmd) {
     return new Promise((resolve) => runscript(cmd, {
         stdio: 'pipe'
@@ -505,13 +506,11 @@ async function compile(data, callback) {
   let cmd = 'sass -C -t compressed -I %1/source/resource/qx/mobile/scss -I %1/source/resource/qx/scss --%3 source/theme/%2/scss:source/resource/%2/css';
   cmd = qx.lang.String.format(cmd, [data.libraries[0], data.applications[0].name]);
   if (!this.argv.watch) {
-     cmd = qx.lang.String.format(cmd, ["", "", "update"]);
-     await runScript(cmd);
+    cmd = qx.lang.String.format(cmd, ["", "", "update"]);
   } else {
     cmd = qx.lang.String.format(cmd, ["", "", "watch"]);
-    runScript(cmd);
   }       
-  callback(null, data);
+  return await runScript(cmd);
 }
 
 ```
@@ -520,14 +519,14 @@ You can run special code on various steps of the build process if you add an eve
 Example:
 
 ```
-function compile(data, callback) {
+function compile(compiler, callback) {
   debugger;
   this.addListener("made",  e => new qx.Promise((fullfiled) => {
       debugger;
       your_special_code;
       fullfiled();
     }));
-    callback(null, data);
+  callback(null, compiler.inputData);
 }
 ```
 Here is a list of possible events, taken from `lib/qx/tool/cli/commands/Compile.js`:

--- a/lib/qx/tool/cli/commands/MConfig.js
+++ b/lib/qx/tool/cli/commands/MConfig.js
@@ -277,23 +277,10 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
       if (!await qx.tool.compiler.files.Utils.safeStat(aPath)) {
         return false;
       }
-      var src = await fs.readFileAsync(aPath, {encoding: "utf8"});
       
       try {
-        const script = new vm.Script(src);
-        
         let p = new Promise((resolve, reject) => {
-          const contextData = {
-              require: require,
-              qx: qx,
-              process: process,
-              compiler: {
-                command: this,
-                inputData,
-                configuration: null
-              }
-            };
-          const context = new vm.createContext(contextData);
+          const script = require(path.resolve(aPath));
 
           function onResolve(data) {
             if (data) {
@@ -303,46 +290,33 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
             }
           }
           
-          try {
-            let result = script.runInContext(context,  {
-              lineOffset: 0,
-              displayErrors: true,
-            });
-            
-            if (contextData.compiler.configuration) {
-              result = contextData.compiler.configuration; 
-            }
-            
-            if (result === undefined) {
-              // If result is undefined, and there is a single extra global which is a function, then
-              //  let's call that function.  This is 
-              let globals = Object.keys(context).filter(name => name != "require" && name != "compiler");
-              if (globals.length == 1 && typeof context[globals[0]] == "function") {
-                result = context[globals[0]];
-              }
-            }
-            
-            if (result instanceof Promise) {
-              result.then(onResolve).catch(reject);
-              
-            } else if (typeof result == "function") {
-              let fnResult = result((err, data) => {
-                if (err) {
+          if (typeof script == "function") {
+            try {
+              let result = script({
+                command: this,
+                inputData
+              }, (err, data) => {
+                if (err)
                   reject(err);
-                }
-                onResolve(data);
+                else
+                  onResolve(data);
               });
-              if (fnResult instanceof Promise) {
-                fnResult.then(onResolve).catch(reject);
+              
+              if (result instanceof Promise) {
+                result.then(onResolve).catch(reject);
+                
+              } else if (result) {
+                onResolve(result);
               }
               
-            } else {
-              onResolve(result);
+            }catch(ex) {
+              reject(ex);
             }
             
-          }catch(ex) {
-            reject(ex);
+          } else {
+            onResolve(script);
           }
+            
         });
         
         return await p;


### PR DESCRIPTION
Switches to using `require` instead of `require('vm').Script` to load compile.js; this is because while `vm` allows sandboxing code into a separate context, there is no implementation of `require()` in that sandbox.  The recommended way is to pass `require` in, but that breaks with Qooxdoo classes because they are loaded into the global scope of the compiler, which means that `require()` in compile.js will not update the global scope for compile.js.

EG the code for compile.js in API viewer was failing because this code:
```
require(path.join(lib.getRootDir(), lib.getSourcePath(), "qxl/apiviewer/ClassLoader.js"));
```
would return an empty object and `qxl.apiviewer.ClassLoader === undefined`; this happened because `require()` loads into the compiler scope and not into `compile.js` scope.

As compile.js is now a module, this means changing the implementation of the API and docs