### PR TITLE
Small fixes to prevent migration warnings + formatting

### DIFF
--- a/Manifest.json
+++ b/Manifest.json
@@ -1,44 +1,36 @@
 {
   "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json",
-  "info" :
-  {
-    "name" : "qxcompiler",
-
-    "summary" : "the qooxdoo compiler",
-    "description" : "",
-
-    "homepage" : "https://github.com/qooxdoo/qooxdoo-compiler",
-
-    "license" : "MIT license",
-    "authors" : [
-  {
+  "info": {
+    "name": "qxcompiler",
+    "summary": "The new fast JavaScript Compiler for Qooxdoo",
+    "description": "The Qooxdoo-Compiler is the new compiler and command line interface for Qooxdoo applications. It is written in Node.JS Javascript and replaces the Python-based generator.",
+    "homepage": "https://github.com/qooxdoo/qooxdoo-compiler",
+    "license": "MIT license",
+    "authors": [
+      {
         "name": "John Spackman (johnspackman)",
         "email": "john.spackman@zenesis.com"
-  },
-  {
-    "name": "Christian Boulanger (cboulanger)",
-    "email": "info@bibliograph.org"
-  },
-  {
+      },
+      {
+        "name": "Christian Boulanger (cboulanger)",
+        "email": "info@bibliograph.org"
+      },
+      {
         "name": "Henner Kollmann (hkollmann)",
         "email": "Henner.Kollmann.gmx.de"
-  }
-],
-
-    "version" : "1.0.0-beta"
+      }
+    ],
+    "version": "1.0.0-beta"
   },
-
-  "provides" :
-  {
-    "namespace"   : "qxcompiler",
-    "encoding"    : "utf-8",
-    "class"       : "source/class",
-    "resource"    : "source/resource",
-    "translation" : "source/translation"
+  "provides": {
+    "namespace": "qxcompiler",
+    "encoding": "utf-8",
+    "class": "source/class",
+    "resource": "source/resource",
+    "translation": "source/translation"
   },
-
   "requires": {
-    "@qooxdoo/framework": "^6.0.0-alpha-20190511-1022",
-    "@qooxdoo/compiler" : "^1.0.0-beta"
+    "@qooxdoo/framework": "^6.0.0-alpha",
+    "@qooxdoo/compiler": "^1.0.0-beta"
   }
 }

--- a/qx-lock.json
+++ b/qx-lock.json
@@ -16,5 +16,6 @@
       "repo_name": "qooxdoo/qxl.versionlabel",
       "repo_tag": "v0.1.2"
     }
-  ]
+  ],
+  "version": "2.1"
 }


### PR DESCRIPTION
This will prevent to have to call `qx pkg migrate` and `qx compile --force` to upgrade the two files. 