### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Qooxdoo Compiler and Command Line Interface
 
-**NOTE** If you have previous installed `qooxdoo-cli`, please uninstall it before continuing
-
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/qooxdoo/qooxdoo)
 [![Build Status](https://travis-ci.org/qooxdoo/qooxdoo-compiler.svg?branch=master)](https://travis-ci.org/qooxdoo/qooxdoo-compiler)
 
@@ -14,136 +12,94 @@ Qooxdoo-Compiler is the new compiler and command line interface for Qooxdoo (htt
 * Written in 100% Javascript
 * API based, easily extended and with dependency information available at runtime
 
-One of the top goals of this project is to be very fast and lightweight - fast enough to detect code changes and recompile  applications on the fly on a production server, with an application recompile costing a few hundreds of milliseconds.
+One of the top goals of this project is to be very fast and lightweight - fast
+enough to detect code changes and recompile  applications on the fly on a
+production server, with an application recompile costing a few hundreds of
+milliseconds.
 
-The included command line utility allows you create, build and manage [qooxdoo](http://www.qooxdoo.org) applications (note that Qooxdoo-Compiler now incorporates the Qooxdoo-CLI project, which used to be a separate repo).
-
-- [qooxdoo command line interface](#qooxdoo-compiler-and-command-line-interface)
-    - [Develoment status](#development-status)
-    - [Prerequisites](#prerequisites)
-    - [Installation](#installation)
-    - [Installation for Development](#installation-for-development)
-    - [Example command line usage](#example-command-line-usage)
-    - [Current State Of Play](#current-state-of-play)
-    - [Demo Browser)[#demo-browser)
-    - [Mini Web Server](#mini-web-server)
-    - [Frequently Asked Questions](#frequently-asked-questions)
-    - CLI Documentation
-        - [Commands](docs/cli/commands.md)
-        - [Compiler](docs/cli/compiler.md)
-          - [compile.json](docs/configuration/compile.md)
-        - [Web Server](docs/cli/serve.md)
-        - [Create a new project](docs/cli/create-a-new-project.md)
-        - [qooxdoo-contrib system](docs/cli/qooxdoo-contrib-system.md)
-    - Compiler Documentation
-        - [API - Overview](docs/compiler/API.md)
-        - [Dependencies - How they are handled in Qooxdoo-Compiler](docs/compiler/Dependencies.md)
-        - [Custom Application Startup](docs/compiler/CustomAppStartup.md)
-        - [Using Icon Fonts](docs/compiler/IconFonts.md)
-        - [Special Loader URLs](docs/compiler/LoaderUrls.md)
-        - [Manifest.json](docs/configuration/Manifest.md)
-        - [Meta Data Output By The Compiler](docs/compiler/MetaData.md)
+The included command line utility allows you create, build and manage
+[qooxdoo](http://www.qooxdoo.org) applications (note that Qooxdoo-Compiler now
+incorporates the Qooxdoo-CLI project, which used to be a separate repo).
 
 ## Development status
-Beta. The API is still likely to change, but not fundamentally.
+
+Beta. The API has mostly stabilized, we will provide a migration path for any
+backward-incompatible changes.
 
 ## Prerequisites
-- **Node** Currently requires NodeJS v8. The released version will be transpiled to support earlier node versions, but whichever version you choose to use we recommend you consider `nvm` to ease installing and switching between node versions - you can find the Linux version at http://nvm.sh and there is a version for Windows at https://github.com/coreybutler/nvm-windows
 
-- **Qooxdoo** Currently requires the latest [master of the Qooxdoo repo](https://github.com/qooxdoo/qooxdoo) - although `master` is cutting edge, we take care to keep it stable and suitable for production use (although use at your own risk, obviously).  Several of the core development team use `master` on live, production sites with real users ... so you know that we're committed to delivering a stable product. 
+- **Node** Currently requires NodeJS >= v8. We recommend you consider `nvm` to
+ease installing and switching between node versions - you can find the Linux
+version at http://nvm.sh and there is a version for Windows at
+https://github.com/coreybutler/nvm-windows
+
+- **Qooxdoo** The compiler works with all qooxdoo versions >= v6.0.0, which is 
+contained in the current master branch. 
  
-
 Install `nvm` and then:
 
 ```bash
-nvm install 8
-nvm use 8
+nvm install 8 # or 10
+nvm use 8 # or 10
 ```
 
-## Installation
-- Install qooxdoo-compiler, create a sample application and compile it
+## Test drive
+
+For more detailed information about installation and use of the compiler, refer
+to the [documentation](docs/readme.md). 
+
+Here's how you can do a quick test drive using `npx` which doesn't install anything
+permanent
+
 ```bash
-npm install -g qxcompiler
-qx create myapp
+npx qx create myapp --noninteractive
 cd myapp
-qx compile
+npx qx package install qooxdoo/qxl.apiviewer
+npx qx package install qooxdoo/qxl.widgetbrowser
+npx qx serve
 ```
-
-## Installation for Development
-- Install qooxdoo-compiler 
-```bash
-git clone https://github.com/qooxdoo/qooxdoo-compiler
-cd qooxdoo-compiler
-npm install
-```
-
-
-## Example command line usage
-```bash
-qx create myapp -I # creates the foo application skeleton non-interactively
-cd myapp
-
-# (optional) install contrib libraries
-qx contrib update # updates the local cache with information on available contribs 
-qx contrib list # lists contribs compatible with myapp's qooxdoo version, determine installation candidate
-qx contrib install johnspackman/UploadMgr # install UploadMgr contrib library 
-
-# compile the application, using the compile.json default configuration values 
-qx compile
-```
-
-Use `--all` if you don't get any contribs listed or if the ones you are 
-looking for are missing. The reason is that they might not declare 
-compatibility to the qooxdoo version you are using yet, even though they are 
-technically compatible. 
-
-
-## Mini Web Server
-Although many applications will run perfectly well when loaded via a `file://` URL, browser security means that some applications *must* use an `http://` url and to support this the CLI includes a mini web server which works with the continuous compilation.
-
-See [docs/cli/serve](docs/cli/serve) for more details, but as an example this is all you need to constantly compile your application and start the web server:
-
-```
-$ qx serve
-```
-
-
-
-## Current state of play
-Qooxdoo Compiler is a BETA RELEASE - at this stage, the compiler is expected to be able to compile production applications (use at your own risk) but still has some ancillary features such as API viewer and TestRunner maker which would be required in order to be a release candidate for Qooxdoo 6.0.
-
-It is currently (October 2017) in use on one major project which is in pre-production testing with real users, and another is about to be released; Qooxdoo Compiler is used for source and build releases, and while there may be some issues that will crop up it is stable enough for most users.
-
-
-
-
-## Demo Browser
-The Demo Browser is compiled by running demos/js/compile-demo-browser.js - it will create the Demo Browser in testdata/demobrowser/
-
+Wait for the message `Web server started, please browse to http://localhost:8080`,
+then open that address in the browser. 
 
 ## Frequently Asked Questions
 
+## Is the compiler stable enough to be used in a production project?
+
+Qooxdoo Compiler is a BETA RELEASE and of course, you use at your own risk.
+However, it is in use in several major production applications maintained by the
+qooxdoo core developers and therefore you can be fairly confident that we cherish
+stability and every major bug that comes up will be fixed ASAP. 
+
 ### Gotchas
-Number one gotcha is that you have to run the compiler every time you change your code, because it's being transpiled.
-The `qx compile` command has a `--watch` parameter that enables continuous compilation.  Note that the `qx serve` command
-always used continuous compilation.
 
-The old style compiler hints (eg #require, #asset etc) have been deprecated in generate.py for some time now, and they
-are not supported in Qooxdoo-Compiler at all (there will be some warnings output "real soon now" but it is a good idea to do a quick grep through your code)
+Number one gotcha is that you have to run the compiler every time you change
+your code, because it's being transpiled. The `qx compile` command has a
+`--watch` parameter that enables continuous compilation.  Note that the `qx
+serve` command always used continuous compilation.
 
+### What about config.json? QOOXDOO_PATH?
 
+`config.json` is not used by QxCompiler; the `qx` command is using a new, and much
+simpler configuration [file called `compile.json`](docs/configuration/compile.md).
+The path to the qooxdoo library does not need to be specified since the compiler
+comes with its own copy of the framework, if this is not what you want, you can
+use the CLI to set the path:
+```
+qx config set qx.libraryPath /path/to/qooxdoo/framework
+```
 
 ### Is Qooxdoo-Compiler a complete replacement for generate.py?
-Not yet - QxCompiler is focused on compiling applications (including collecting resources) whereas generate.py includes features for building and running test suites, creating API documentation, building distributions, creating skeleton applications, etc.
 
-The goal is to move to a 100% Javascript toolchain, and QxCompiler will be used as the base API for implementing all the compilation-related features; by using existing tools like npm, repackaging the API viewer and TestRunner as separate contribs generate.py will be deprecated in 6.0 and removed in 7.0.
+The compiler is a full equivalent as far as compiling is concerned, and much
+faster at that. However, its domain is compiling applications (including
+collecting resources) whereas generate.py included features for building and
+running test suites, creating API documentation, building distributions,
+creating skeleton applications, etc. These features have not been replicated.
+Instead, you can do all these things with code now in a [file called `compile.js`](docs/configuration/compile.md#compilejs)
 
+## Contributing and Getting In Touch
 
-### What about config.json?  QOOXDOO_PATH?
-config.json is not used by QxCompiler; the `qx` command is using a new, and much simpler configuration file called compile.json
-
-
-### Contributing and Getting In Touch
-Please get stuck in to any aspects you'd like to work on - I'm open to pull requests, and you can contact me to chat 
-about features you'd like to see or help on using or extending Qooxdoo-Compiler.  The best place to talk about it is on Gitter at https://gitter.im/qooxdoo/qooxdoo
-
+Please get stuck in to any aspects you'd like to work on - We're open to pull
+requests, and you can contact us to chat about features you'd like to see or
+help on using or extending Qooxdoo-Compiler.  The best place to talk about it is
+on Gitter at https://gitter.im/qooxdoo/qooxdoo

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -1,6 +1,8 @@
 # Persistent Configuration
 
-Some commands require (or benefit from) having persistent configuration; this is accessed via the `qx config` command and the data is stored in a directory called `.qooxdoo` inside your home directory.
+Some commands require (or benefit from) having persistent configuration; this is
+accessed via the `qx config` command and the data is stored in a directory
+called `.qooxdoo` inside your home directory.
 
 The `qx config` supports the following:
 
@@ -18,7 +20,9 @@ Options:
                                                                        [boolean]
 ```
 
-Configuration is based on simple key/value pairs, and while you can access keys with any name you likee, the `qx` command will look for the following special keys:
+Configuration is based on simple key/value pairs, and while you can access keys
+with any name you likee, the `qx` command will look for the following special
+keys:
 
 `github.token` - this is the API token used when connecting to GitHub
 `qx.libraryPath` - this is the Qooxdoo library to use when compiling your application

--- a/docs/cli/packages.md
+++ b/docs/cli/packages.md
@@ -6,7 +6,6 @@ new name. In the meantime, you'll probably find references to "contribs"
 everywhere. The new system is fully backwards compatible to "qooxdoo-contrib",
 but will issue deprecation warnings when the old commands are used.*
 
-
 ## Overview
 
 qooxdoo's "plugin architecture" is called qooxdoo package system. It does not
@@ -426,8 +425,6 @@ supported, which takes an array of version numbers. You need to specify each and
 every version that you want to support, and any new qooxdoo version will break
 compatibility. Support for this will be removed in version 7.
 
-
-
 ### qx package and NPM 
 
 There are two ways in which the package system and the NPM package manager relate
@@ -439,13 +436,12 @@ a) Since the compiler is an NPM module, one might ask why we aren't using NPM
 for qooxdoo packages. Why create an additional package system? qooxdoo packages
 work similarly to NPM, but without storing releases in a centralized repository.
 They are (currently) downloaded directly from GitHub releases because that is
-where most qooxdoo code is developed and published. If there is enough demand,
-we might support other repository providers in the future.
+where most qooxdoo code is developed and published.
 
 b) Under normal circumstances, a package does not need to use NPM
 or maintain a `package.json` file. In particular, neither the `@qooxdoo/compiler` nor
 the `@qooxdoo/framework` npm packages should be NPM dependencies of the package.
 Instead, they are installed either at the level of the application or globally
-(see the [docs on installation](../../README.md#installation)). You might want
+(see the [docs on installation](../readme.md)). You might want
 to use NPM for development-time task such as transpiling your code, but all
 NPM-related information in the package will be ignored by the compiler.

--- a/docs/cli/serve.md
+++ b/docs/cli/serve.md
@@ -1,8 +1,16 @@
 ### Mini Web Server
 
-Although many applications will run perfectly well when loaded via a `file://` URL, browser security means that some applications *must* use an `http://` url.  The CLI includes the `qx serve` command which operates a mini web server running (by default) on `http://localhost:8080`.  You can customise the port with the `--listenPort=<portnumber>` argument, or by adding `serve: { listenPort: <portnumber> }` to your `compile.json`; the command line option will take precedence over the `compile.json` setting.  
+Although many applications will run perfectly well when loaded via a `file://`
+URL, browser security means that some applications *must* use an `http://` url. 
+The CLI includes the `qx serve` command which operates a mini web server running
+(by default) on `http://localhost:8080`.  You can customise the port with the
+`--listenPort=<portnumber>` argument, or by adding `serve: { listenPort:
+<portnumber> }` to your `compile.json`; the command line option will take
+precedence over the `compile.json` setting.
 
-An important feature is that `qx serve` will constantly compile your application in the background, every time you edit the code - this is equivalent to `qx compile --watch` plus the web server.
+An important feature is that `qx serve` will constantly compile your application
+in the background, every time you edit the code - this is equivalent to `qx
+compile --watch` plus the web server.
 
 As an example this will compile your application and start the web server on port 8082 
 
@@ -42,5 +50,8 @@ Options:
 
 ```
 
-Note that the `qx serve` command supports exactly the same options as `qx compile`, with the exception of `--watch` because that is always enabled; for more details of the options and the compilation process, please see [compiler.md](compiler.md)
+Note that the `qx serve` command supports exactly the same options as `qx
+compile`, with the exception of `--watch` because that is always enabled; for
+more details of the options and the compilation process, please see
+[compiler.md](compiler.md)
  

--- a/docs/configuration/compile.md
+++ b/docs/configuration/compile.md
@@ -278,7 +278,7 @@ If you add the `environment` block at the top level of the compile.json (as in t
 ```
 In this example, `demoapp.myCustomSetting` is always 3 for the `appone` Application, and either 1 or 2 for `apptwo` depending on whether you're compile a `source` Target or a `build` Target.
 
-###Code Elimination
+### Code Elimination
 When the compiler can absolutely determine, in advance, the values for an environment variable,
 it will evaluate the expression in advance and eliminate code which can never be called; for example,
 the most common example of this is `qx.debug` which is true for the Source Target and false for Build Targets.


### PR DESCRIPTION
This updates the documentation to the current state of the code. Still alot is missing, in particular better documentation on migrating from v5 to v6, and even more specifically, how to transition from `package.json` to `compile.(json|js)`. It would be great if @johnspackman could add something to this effect.

We need to think about how to integrate this documentation with @oetiker's new doc system. Should we maintain it here and periodically copy it over to a dedicated documentation repo? How to synchronize versions and documentation, then? One great thing about the new system is the button "improve documentation"  in the docs themselves - but this only works if the docs are in one repo...