### PR TITLE
Fix the schema urls to contain the schema version in the file name, not in the path

### DIFF
--- a/Manifest.json
+++ b/Manifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json",
+  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/Manifest-1-0-0.json",
   "info": {
     "name": "qxcompiler",
     "summary": "The new fast JavaScript Compiler for Qooxdoo",

--- a/compile.json
+++ b/compile.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/compile.json",
+  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json",
   "targets": [
     {
       "type": "source",

--- a/source/class/qx/tool/config/Compile.js
+++ b/source/class/qx/tool/config/Compile.js
@@ -25,7 +25,7 @@ qx.Class.define("qx.tool.config.Compile", {
   statics: {
     config: {
       fileName: "compile.json",
-      version: "1"
+      version: "^1.0.0"
     }
   },
   construct: function() {

--- a/source/class/qx/tool/config/Lockfile.js
+++ b/source/class/qx/tool/config/Lockfile.js
@@ -19,7 +19,7 @@
 /**
  * A model for the lockfile, which has a version, but no "official" schema (yet)
  */
-const version = "2.1";
+const version = "2.1.0";
 qx.Class.define("qx.tool.config.Lockfile", {
   extend: qx.tool.config.Abstract,
   type: "singleton",

--- a/source/class/qx/tool/config/Manifest.js
+++ b/source/class/qx/tool/config/Manifest.js
@@ -25,7 +25,7 @@ qx.Class.define("qx.tool.config.Manifest", {
   statics: {
     config: {
       fileName: "Manifest.json",
-      version: "1"
+      version: "1.0.0"
     }
   },
   construct: function() {

--- a/source/class/qx/tool/config/Registry.js
+++ b/source/class/qx/tool/config/Registry.js
@@ -25,7 +25,7 @@ qx.Class.define("qx.tool.config.Registry", {
   statics: {
     config: {
       fileName:  "qooxdoo.json",
-      version: "1"
+      version: "1.0.0"
     }
   },
   construct: function() {

--- a/source/class/qx/tool/utils/Json.js
+++ b/source/class/qx/tool/utils/Json.js
@@ -92,16 +92,24 @@ qx.Class.define("qx.tool.utils.Json", {
      * Identify the type and version of the config file schema in the data that
      * has been passed. Return an object containing type and version of the json
      * schema, or null if no schema could been detected
+     * Todo: This needs to be rewritten.
      * @param data {Object} JSON data
      * @return {{type,version}|null}
      */
     getSchemaInfo: function(data) {
       let schemaInfo = {};
       if (data.$schema) {
-        let match = data.$schema.match(/\/v([^/]+)\/([^.]+)\.json$/);
+        let match = data.$schema.match(/\/([^-]+)-([^.]+)\.json$/);
         if (match) {
-          schemaInfo.type = match[2].toLocaleLowerCase();
-          schemaInfo.version = match[1];
+          schemaInfo.type = match[1].toLocaleLowerCase();
+          schemaInfo.version = match[2].replace(/-/g, ".");
+        } else {
+          // deprecated schema url
+          let match = data.$schema.match(/\/v([^/]+)\/([^.]+)\.json$/);
+          if (match) {
+            schemaInfo.type = match[2].toLocaleLowerCase();
+            schemaInfo.version = match[1];
+          }
         }
         // guess file type, this would be easy with the file name!
       } else if (data.targets) {

--- a/source/resource/qx/tool/cli/templates/skeleton/desktop/Manifest.tmpl.json
+++ b/source/resource/qx/tool/cli/templates/skeleton/desktop/Manifest.tmpl.json
@@ -1,5 +1,5 @@
 {
- "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json",
+ "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/Manifest-1-0-0.json",
   "info" :
   {
     "name" : "${name}",

--- a/source/resource/qx/tool/cli/templates/skeleton/desktop/compile.tmpl.json
+++ b/source/resource/qx/tool/cli/templates/skeleton/desktop/compile.tmpl.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/compile.json",
+  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json",
   "targets": [
     {
       "type": "source",

--- a/source/resource/qx/tool/cli/templates/skeleton/mobile/Manifest.tmpl.json
+++ b/source/resource/qx/tool/cli/templates/skeleton/mobile/Manifest.tmpl.json
@@ -1,5 +1,5 @@
 {
- "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json",
+ "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/Manifest-1-0-0.json",
   "info" :
   {
     "name" : "${name}",

--- a/source/resource/qx/tool/cli/templates/skeleton/mobile/compile.tmpl.json
+++ b/source/resource/qx/tool/cli/templates/skeleton/mobile/compile.tmpl.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/compile.json",
+  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json",
   "targets": [
     {
       "type": "source",

--- a/source/resource/qx/tool/cli/templates/skeleton/package/Manifest.tmpl.json
+++ b/source/resource/qx/tool/cli/templates/skeleton/package/Manifest.tmpl.json
@@ -1,5 +1,5 @@
 {
- "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json",
+ "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/Manifest-1-0-0.json",
   "info" :
   {
     "name" : "${name}",

--- a/source/resource/qx/tool/cli/templates/skeleton/package/compile.tmpl.json
+++ b/source/resource/qx/tool/cli/templates/skeleton/package/compile.tmpl.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/compile.json",
+  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json",
   "targets": [
     {
       "type": "source",

--- a/source/resource/qx/tool/cli/templates/skeleton/server/Manifest.tmpl.json
+++ b/source/resource/qx/tool/cli/templates/skeleton/server/Manifest.tmpl.json
@@ -1,5 +1,5 @@
 {
- "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json",
+ "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/Manifest-1-0-0.json",
   "info" :
   {
     "name" : "${name}",

--- a/source/resource/qx/tool/cli/templates/skeleton/server/compile.tmpl.json
+++ b/source/resource/qx/tool/cli/templates/skeleton/server/compile.tmpl.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/compile.json",
+  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json",
   "targets": [
     {
       "type": "source",

--- a/source/resource/qx/tool/schema/Manifest-1-0-0.json
+++ b/source/resource/qx/tool/schema/Manifest-1-0-0.json
@@ -1,7 +1,7 @@
 {
   "title": "Manifest.json Schema",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json",
+  "$id": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/Manifest-1-0-0.json",
   "description": "qooxdoo's Manifest files serve to provide meta information for a library in a structured way. Their syntax is in JSON. They have a more informational part (keyed info), which is more interesting for human readers, a technical part (named provides) that is used in the processing of generator configurations, and a part named externalResources to include CSS and Javascript files.",
   "type": "object",
   "required": [
@@ -13,7 +13,11 @@
     "$schema": {
       "type": "string",
       "description": "the json schema of the version of Manifest.json",
-      "const": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json"
+      "enum": [
+        "https://www.qooxdoo.org/schema/Manifest-1-0-0.json",
+        "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/Manifest-1-0-0.json",
+        "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json"
+      ]
     },
     "info": {
       "type": "object",

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -1,7 +1,7 @@
 {
   "title": "compile.json Schema",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/compile.json",
+  "$id": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json",
   "description": "compile.json controls the qx compile command, and while you can use command line parameters to compile an application, most applications will require one.",
   "type": "object",
   "required": [
@@ -15,7 +15,11 @@
     "$schema": {
       "type": "string",
       "description": "the json schema of the version of compile.json",
-      "const": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/compile.json"
+      "enum": [
+        "https://www.qooxdoo.org/schema/compile-1-0-0.json",
+        "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/compile-1-0-0.json",
+        "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/compile.json"
+      ]
     },
     "applications": {
       "type":"array",
@@ -277,7 +281,7 @@
       ],
       "items": {
         "type": "string"
-      }  
+      }
     },
     "babelOptions": {
       "type": "object",

--- a/source/resource/qx/tool/schema/qooxdoo-1-0-0.json
+++ b/source/resource/qx/tool/schema/qooxdoo-1-0-0.json
@@ -1,7 +1,7 @@
 {
   "title": "qooxdoo.json Schema",
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/qooxdoo.json",
+  "$id": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/qooxdoo-1-0-0.json",
   "description": "qooxdo.json is a registry for qooxdoo libraries in a repository/package.",
   "type": "object",
   "required": [
@@ -12,7 +12,11 @@
     "$schema": {
       "type": "string",
       "description": "the json schema of the version of qooxdoo.json",
-      "const": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/qooxdoo.json"
+      "enum": [
+        "https://www.qooxdoo.org/schema/qooxdoo-1-0-0.json",
+        "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/qooxdoo-1-0-0.json",
+        "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/qooxdoo.json"
+      ]
     },
     "libraries": {
       "description": "An array of objects with at least a 'path' property, containing the path to the library",

--- a/test/testapp/Manifest.json
+++ b/test/testapp/Manifest.json
@@ -21,7 +21,7 @@
     "translation": "source/translation",
     "type": "application"
   },
-  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/Manifest.json",
+  "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/source/resource/qx/tool/schema/Manifest-1-0-0.json",
   "requires": {
     "@qooxdoo/compiler": "^1.0.0-beta",
     "@qooxdoo/framework": "^6.0.0-alpha"


### PR DESCRIPTION
The schema version is encoded in the file name following https://snowplowanalytics.com/blog/2014/05/13/introducing-schemaver-for-semantic-versioning-of-schemas/