### PR TITLE
__external__ is not resolved. 

### DIFF
--- a/source/class/qx/tool/compiler/targets/Target.js
+++ b/source/class/qx/tool/compiler/targets/Target.js
@@ -400,7 +400,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.Target", {
                 if (pathNs == libnamespace || analyser.findLibrary(pathNs)) {
                   configdata.urisBefore.push(pathNs + ":" + path);
                 } else {
-                  configdata.urisBefore.push("__external__:" + path);
+                  configdata.urisBefore.push(libnamespace + ":" + path);
                 }
               });
             }


### PR DESCRIPTION
This uses the old way and add libnamespace instead of __external__. Same behavior as css.