### PR TITLE
exposes the `.getMaker()` method publicly and adds missing tests

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4929,6 +4929,11 @@
         "ci-info": "^1.5.0"
       }
     },
+    "is-class-hotfix": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/is-class-hotfix/-/is-class-hotfix-0.0.6.tgz",
+      "integrity": "sha512-0n+pzCC6ICtVr/WXnN2f03TK/3BfXY7me4cjCAqT8TYXEl0+JBRoqBo94JJHXcyDSLUeWbNX8Fvy5g5RJdAstQ=="
+    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -5132,6 +5137,16 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
+      }
+    },
+    "is-type-of": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-type-of/-/is-type-of-1.2.1.tgz",
+      "integrity": "sha512-uK0kyX9LZYhSDS7H2sVJQJop1UnWPWmo5RvR3q2kFH6AUHYs7sOrVg0b4nyBHw29kRRNFofYN/JbHZDlHiItTA==",
+      "requires": {
+        "core-util-is": "^1.0.2",
+        "is-class-hotfix": "~0.0.6",
+        "isstream": "~0.1.2"
       }
     },
     "is-typedarray": {
@@ -7576,6 +7591,30 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
         "is-promise": "^2.1.0"
+      }
+    },
+    "runscript": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/runscript/-/runscript-1.3.1.tgz",
+      "integrity": "sha512-SgGd244ZxujjEA5DB9WndeI7GEtmNPzzx/k5ChlqZeAcuwq/YLUzm5KQZMhOvmoiw9tREwt6/pE+MwAizM7UVQ==",
+      "requires": {
+        "debug": "^2.6.8",
+        "is-type-of": "^1.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "rx-lite": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "puppeteer-to-istanbul": "^1.2.2",
     "replace-in-file": "^4.0.0",
     "rimraf": "^2.6.2",
+    "runscript": "^1.3.1",
     "semver": "^5.7.0",
     "set-value": "^3.0.0",
     "tmp": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "puppeteer-to-istanbul": "^1.2.2",
     "replace-in-file": "^4.0.0",
     "rimraf": "^2.6.2",
-    "runscript": "^1.3.1",
     "semver": "^5.7.0",
     "set-value": "^3.0.0",
     "tmp": "0.0.33",
@@ -96,6 +95,7 @@
     "metalsmith-layouts": "^2.3.0",
     "metalsmith-markdown": "^1.1.0",
     "metalsmith-permalinks": "^2.0.0",
+    "runscript": "^1.3.1",
     "tape": "^4.9.1"
   },
   "eslintConfig": {

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -260,12 +260,14 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
     __maker: null,
     __config: null,
 
-    _getMaker: function() {
+    getMaker: function() {
       return this.__maker;
     },
+    
     _getConfig: function() {
       return this.__config;
     },
+    
     /*
      * @Override
      */

--- a/source/class/qx/tool/cli/commands/MConfig.js
+++ b/source/class/qx/tool/cli/commands/MConfig.js
@@ -163,7 +163,7 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
       
       await compilerApi.afterLibrariesLoaded();
       
-      return config;
+      return compilerApi.getConfiguration();
     },
 
     /*

--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -157,7 +157,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
     /* @ignore qx.tool.$$resourceDir */
 
     runWebServer: function() {
-      var maker = this._getMaker();
+      var maker = this.getMaker();
       var config = this._getConfig();
       var target = maker.getTarget();
       var apps = maker.getApplications();

--- a/test/testapp/compile.js
+++ b/test/testapp/compile.js
@@ -30,7 +30,6 @@ qx.Class.define("qxl.compilertests.testapp.LibraryApi", {
     },
     
     _onMaking() {
-      debugger;
       // The "making" event can be fired more than once (eg when watching) so we want to start our own
       //  sass watch once
       if (this.__startedSassWatch)

--- a/test/testapp/compile.js
+++ b/test/testapp/compile.js
@@ -1,5 +1,7 @@
 const fs = require("fs");
 const path = require("path");
+const runscript = require('runscript');
+const util = require('util');
 
 qx.Class.define("qxl.compilertests.testapp.CompilerApi", {
   extend: qx.tool.cli.api.CompilerApi,
@@ -19,9 +21,62 @@ qx.Class.define("qxl.compilertests.testapp.LibraryApi", {
   extend: qx.tool.cli.api.LibraryApi,
   
   members: {
+    __startedSassWatch: false,
+    
     async load() {
       let command = this.getCompilerApi().getCommand();
+      command.addListener("making", () => this._onMaking());
       command.addListener("checkEnvironment", e => this._appCompiling(e.getData().application, e.getData().environment));
+    },
+    
+    _onMaking() {
+      debugger;
+      // The "making" event can be fired more than once (eg when watching) so we want to start our own
+      //  sass watch once
+      if (this.__startedSassWatch)
+        return;
+      let command = this.getCompilerApi().getCommand();
+      let maker = command.getMaker();
+      let analyser = maker.getAnalyser();
+      
+      // Figure out the command line to execute
+      let sassType = "update";
+      if (command.argv.watch) {
+        this.__startedSassWatch = true;
+        sassType = "watch";
+      }
+      
+      let qxPath = analyser.getQooxdooPath();
+      let cmd = `sass -C -t compressed -I ${qxPath}/source/resource/qx/mobile/scss -I ${qxPath}/source/resource/qx/scss --${sassType}`;
+      analyser.getLibraries().forEach(library => {
+        let name = library.getNamespace();
+        if (fs.existsSync(`source/theme/${name}/scss`))
+          cmd += ` source/theme/${name}/scss:source/resource/${name}/css` 
+      });
+      
+      // Helper method to output from the sass command to the console
+      const writeOutput = stdio => {
+        if (stdio.stdout)
+          console.log(stdio.stdout.toString());
+        if (stdio.stderr)
+          console.log(stdio.stderr.toString());
+      };
+      
+      // Run Sass; we don't wait for the process to end because it won't if we're using watching
+      runscript(cmd, {
+          stdio: 'pipe'
+        })
+        .then(stdio => {
+          console.log('Run "%s"', cmd);
+          writeOutput(stdio);
+        })
+        .catch(err => {
+          console.error(err.toString());
+          writeOutput(err.stdio);
+        });
+
+      // Return null to suppress warning about promise created but not waited for
+      return null;
     },
     
     _appCompiling(application, environment) {

--- a/test/testapp/source/resource/testapp/css/sample.css
+++ b/test/testapp/source/resource/testapp/css/sample.css
@@ -1,0 +1,3 @@
+#root{background-color:red}
+
+/*# sourceMappingURL=sample.css.map */

--- a/test/testapp/source/resource/testapp/css/sample.css.map
+++ b/test/testapp/source/resource/testapp/css/sample.css.map
@@ -1,0 +1,9 @@
+{
+	"version": 3,
+	"file": "sample.css",
+	"sources": [
+		"../../../../stdin"
+	],
+	"names": [],
+	"mappings": "AAEA,AAAA,KAAK,AAAC,CACJ,gBAAgB,CAHR,GAAG,CAIZ"
+}

--- a/test/testapp/source/theme/testapp/scss/sample.scss
+++ b/test/testapp/source/theme/testapp/scss/sample.scss
@@ -1,0 +1,5 @@
+$bgcolor: red;
+
+#root {
+  background-color: $bgcolor;
+}


### PR DESCRIPTION
Apologies for the late entry on this one, I intended for this to be part of the last PR.

The examples call the `._getMaker()` method of the command in order to integrate fully with the compiler API, but this is not ideal given that it is a protected method.  The maker is an essential entry point, so this change exposes it publicly.

Once this is merged, I'll update API viewer and Demo browser to match

