### PR TITLE
Fixes crash and improve console output

### DIFF
--- a/source/class/qx/tool/cli/Cli.js
+++ b/source/class/qx/tool/cli/Cli.js
@@ -29,11 +29,13 @@ qx.Class.define("qx.tool.cli.Cli", {
 
   members: {
     run: function() {
+      /*
       if (qx.core.Environment.get("runtime.name") == "rhino") {
         qx.log.Logger.register(qx.log.appender.RhinoConsole);
       } else if (qx.core.Environment.get("runtime.name") == "node.js") {
         qx.log.Logger.register(qx.log.appender.NodeConsole);
       }
+      */
 
       var args = qx.lang.Array.clone(process.argv);
       args.shift();

--- a/source/class/qx/tool/cli/LogAppender.js
+++ b/source/class/qx/tool/cli/LogAppender.js
@@ -67,30 +67,6 @@ qx.Class.define("qx.tool.cli.LogAppender", {
     toTextArray: function(entry) {
       var output = [];
 
-      function zeropad2(val) {
-        if (val < 10) {
-          return "0" + val;
-        }
-        return String(val);
-      }
-      function zeropad3(val) {
-        if (val < 10) {
-          return "00" + val;
-        }
-        if (val < 100) {
-          return "0" + val;
-        }
-        return String(val);
-      }
-      
-      /*
-      var dt = entry.time;
-      var str = dt.getFullYear() + "-" + zeropad2(dt.getMonth() + 1) + "-" + zeropad2(dt.getDate()) + " " +
-        zeropad2(dt.getHours()) + ":" + zeropad2(dt.getMinutes()) + ":" + zeropad2(dt.getSeconds()) + "." + zeropad3(dt.getMilliseconds());
-
-      output.push(str);
-      */
-
       var items = entry.items;
       var item;
       var msg;

--- a/source/class/qx/tool/cli/LogAppender.js
+++ b/source/class/qx/tool/cli/LogAppender.js
@@ -82,11 +82,14 @@ qx.Class.define("qx.tool.cli.LogAppender", {
         }
         return String(val);
       }
+      
+      /*
       var dt = entry.time;
       var str = dt.getFullYear() + "-" + zeropad2(dt.getMonth() + 1) + "-" + zeropad2(dt.getDate()) + " " +
         zeropad2(dt.getHours()) + ":" + zeropad2(dt.getMinutes()) + ":" + zeropad2(dt.getSeconds()) + "." + zeropad3(dt.getMilliseconds());
 
       output.push(str);
+      */
 
       var items = entry.items;
       var item;

--- a/source/class/qx/tool/compiler/Console.js
+++ b/source/class/qx/tool/compiler/Console.js
@@ -117,6 +117,8 @@ qx.Class.define("qx.tool.compiler.Console", {
       // Library errors (@see {Library})
       "qx.tool.compiler.library.emptyManifest": "Empty Manifest.json in library at %1",
       "qx.tool.compiler.library.cannotCorrectCase": "Unable to correct case for library in %1 because it uses source/resource directories which are outside the library",
+      "qx.tool.compiler.library.cannotFindPath": "Cannot find path %2 required by library %1",
+      
 
       // Targets
       "qx.tool.compiler.build.uglifyParseError": "Parse error in output file %4, line %1 column %2: %3",

--- a/source/class/qx/tool/compiler/app/Library.js
+++ b/source/class/qx/tool/compiler/app/Library.js
@@ -140,7 +140,7 @@ qx.Class.define("qx.tool.compiler.app.Library", {
      * @param cb
      */
     loadManifest: function(loadFromDir, cb) {
-      var Console =qx.tool.compiler.Console.getInstance();
+      var Console = qx.tool.compiler.Console.getInstance();
       var t = this;
       let rootDir = loadFromDir;
 
@@ -157,7 +157,8 @@ qx.Class.define("qx.tool.compiler.app.Library", {
           function fixLibraryPath(dir) {
             let d = path.resolve(rootDir, dir);
             if (!fs.existsSync(d)) {
-              return dir;
+              t.warn(Console.decode("qx.tool.compiler.library.cannotFindPath", t.getNamespace(), dir));
+              return qx.Promise.resolve(dir);
             }
             return qx.tool.utils.files.Utils.correctCase(d)
               .then(correctedDir => {
@@ -300,7 +301,14 @@ qx.Class.define("qx.tool.compiler.app.Library", {
         });
       }
 
-      scanDir(path.join(t.getRootDir(), t.getSourcePath()), "", function(err) {
+      let rootDir = path.join(t.getRootDir(), t.getSourcePath());
+      if (!fs.existsSync(rootDir)) {
+        let Console = qx.tool.compiler.Console.getInstance();
+        this.warn(Console.decode("qx.tool.compiler.library.cannotFindPath", t.getNamespace(), rootDir));
+        cb(null, []);
+        return;
+      }
+      scanDir(rootDir, "", function(err) {
         cb(err, classes);
       });
     },


### PR DESCRIPTION
This fixes part of the problem with https://github.com/qooxdoo/qooxdoo-compiler/issues/450, where a missing library `class` directory causes an odd error message; it also tries to improve the console output.

Previously, there were two log appenders, one was `NodeConsole` which output everything and the other is `qx.tool.cli.LogAppender` which outputs only if a defined level is used, and also outputs date/time information with each entry.  The result is a lot of duplication of output and extra noise in the form of date/time data (down to the millisecond).  This PR reduces it to just `LogAppender` and removes date time output