### PR TITLE
Do NOT just install the current version of @qooxdoo/framework.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "scripts": {
     "test": "cross-os test.os",
-    "postinstall": "npm update --no-save @qooxdoo/framework",
     "compileWebSite": "cd source/resource/qx/tool/cli/serve && node compile.js",
     "lint": "eslint lib"
   },


### PR DESCRIPTION
the current version of the framework is nice for the current version of the compiler, but when running an old compiler this messes up things badly.