### PR TITLE
2 changes:

### DIFF
--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -110,7 +110,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       var maker = this.getMaker();
       var config = this._getConfig();
       var target = maker.getTarget();
-      var apps = maker.getApplications();
+      var apps = maker.getApplications().filter(app => app.isBrowserApp());
 
       const app = express();
       const website = new qx.tool.utils.Website();


### PR DESCRIPTION
   - only list apps which are build for the browwser (qooxdoo server can not run in the browser!)
   - serve  /apps