### PR TITLE
`qx package upgrade -p` will now upgrade to the latest prerelease

### DIFF
--- a/source/class/qx/tool/cli/commands/package/List.js
+++ b/source/class/qx/tool/cli/commands/package/List.js
@@ -82,8 +82,11 @@ qx.Class.define("qx.tool.cli.commands.package.List", {
           "noheaders": {
             alias: "H",
             describe: "Omit header and footer"
+          },
+          "prereleases": {
+            alias: "p",
+            describe: "Include prereleases into latest compatible releases"
           }
-
         },
         handler: function(argv) {
           return new qx.tool.cli.commands.package.List(argv)
@@ -415,7 +418,7 @@ qx.Class.define("qx.tool.cli.commands.package.List", {
             let latestCompatibleVersion = latestCompatibleRelease ? latestCompatibleRelease.replace(/v/, "") : undefined;
             if (compatibility === true &&
               (latestCompatibleRelease === undefined ||
-                (semver.gt(tag_version, latestCompatibleVersion, false) && !prerelease)
+                (semver.gt(tag_version, latestCompatibleVersion, false) && (!prerelease || this.argv.prereleases))
               )
             ) {
               this.__latestCompatible[qooxdoo_version][repo_name] = tag_name;

--- a/source/class/qx/tool/cli/commands/package/Upgrade.js
+++ b/source/class/qx/tool/cli/commands/package/Upgrade.js
@@ -49,6 +49,10 @@ qx.Class.define("qx.tool.cli.commands.package.Upgrade", {
           "dryrun":{
             alias: "d",
             describe: "Show result only, do not actually upgrade"
+          },
+          "prereleases": {
+            alias: "p",
+            describe: "Use prereleases if available"
           }
         },
         handler: function (argv) {
@@ -66,7 +70,14 @@ qx.Class.define("qx.tool.cli.commands.package.Upgrade", {
   members: {
     async process() {
       await this.base(arguments);
-      await (new qx.tool.cli.commands.package.Update({quiet:this.argv.quiet, verbose:this.argv.verbose})).process();
+      await (new qx.tool.cli.commands.package.Update({
+          quiet:true,
+          prereleases: this.argv.prereleases
+      })).process();
+      await (new qx.tool.cli.commands.package.List({
+        quiet:true,
+        prereleases: this.argv.prereleases
+      })).process();
       if (!this.argv.quiet) {
         console.info("Upgrading project dependencies to their latest available releases...");
       }

--- a/source/class/qx/tool/cli/commands/package/Upgrade.js
+++ b/source/class/qx/tool/cli/commands/package/Upgrade.js
@@ -71,8 +71,8 @@ qx.Class.define("qx.tool.cli.commands.package.Upgrade", {
     async process() {
       await this.base(arguments);
       await (new qx.tool.cli.commands.package.Update({
-          quiet:true,
-          prereleases: this.argv.prereleases
+        quiet:true,
+        prereleases: this.argv.prereleases
       })).process();
       await (new qx.tool.cli.commands.package.List({
         quiet:true,


### PR DESCRIPTION
Before, it was not possible to upgrade to a prerelease.