### PR TITLE
fixes issues with mobile

### DIFF
--- a/source/class/qx/tool/compiler/targets/Target.js
+++ b/source/class/qx/tool/compiler/targets/Target.js
@@ -371,13 +371,15 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
           
           function addExternal(arr, type) {
             if (arr) {
-              arr.forEach(path => {
-                if (path.match(/^https?:/)) {
-                  configdata[type].push("__external__:" + path);
+              arr.forEach(filename => {
+                if (filename.match(/^https?:/)) {
+                  configdata[type].push("__external__:" + filename);
                 } else {
-                  let lib = rm.findLibraryForResource(path);
-                  if (lib) {
-                    configdata[type].push(lib.getNamespace() + ":" + path);
+                  let asset = rm.getAsset(filename);
+                  if (asset) {
+                    let str = asset.getDestFilename(t);
+                    str = path.relative(path.join(t.getOutputDir(), "resource"), str);
+                    configdata[type].push(asset.getLibrary().getNamespace() + ":" + str);
                   }
                 }
               });
@@ -491,7 +493,7 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
                 }),
 
                 new qx.Promise((resolve, reject) => {
-                  var assetUris = application.getAssetUris(rm, configdata.environment);
+                  var assetUris = application.getAssetUris(t, rm, configdata.environment);
                   var assets = rm.getAssetsForPaths(assetUris);
                   compileInfo.assets = assets;
 

--- a/source/resource/qx/tool/schema/Manifest-1-0-0.json
+++ b/source/resource/qx/tool/schema/Manifest-1-0-0.json
@@ -206,7 +206,7 @@
           "uniqueItems": true,
           "items": {
             "type": "string",
-            "pattern": "[.]css$"
+            "pattern": "[.]s?css$"
           }
         },
         "script": {


### PR DESCRIPTION
This is the update that allows qxl.mobileshowcase to work.

Included in this change is that Manifest.json externalResources must refer to the resource name (eg `qxl/mobileshowcase/scss/custom.scss`) and NOT the css/custom.css that is output; the compiler will figure it out and use the correct .css file