### PR TITLE
Resource manager fixes

### DIFF
--- a/source/class/qx/tool/cli/commands/MConfig.js
+++ b/source/class/qx/tool/cli/commands/MConfig.js
@@ -161,6 +161,10 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
         }
       }
       
+      if (config.sass && config.sass.compiler !== undefined) {
+        qx.tool.compiler.resources.ScssConverter.USE_V6_COMPILER = config.sass.compiler == "latest";
+      }
+      
       await compilerApi.afterLibrariesLoaded();
       
       return compilerApi.getConfiguration();

--- a/source/class/qx/tool/cli/commands/MConfig.js
+++ b/source/class/qx/tool/cli/commands/MConfig.js
@@ -163,6 +163,8 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
       
       if (config.sass && config.sass.compiler !== undefined) {
         qx.tool.compiler.resources.ScssConverter.USE_V6_COMPILER = config.sass.compiler == "latest";
+      } else {
+        qx.tool.compiler.resources.ScssConverter.USE_V6_COMPILER = null;
       }
       
       await compilerApi.afterLibrariesLoaded();

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -1235,7 +1235,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             ContinueStatement: 1,
             ForStatement: 1,
             TemplateLiteral: 1,
-            AwaitExpression: 1
+            AwaitExpression: 1,
+            DoWhileStatement: 1,
+            ForOfStatement: 1
           };
           let root = path;
           while (root) {
@@ -2331,6 +2333,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
       "WeakMap",
       "WeakSet",
       "arguments",
+      "atob",
+      "btoa",
       "console",
       "clearInterval",
       "clearTimeout",
@@ -2367,6 +2371,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
       "MutationObserver",
       "XPathResult",
       "XMLHttpRequest",
+      "XMLSerializer",
+      "XPathEvaluator",
       "alert",
       "document",
       "history",

--- a/source/class/qx/tool/compiler/resources/ScssConverter.js
+++ b/source/class/qx/tool/compiler/resources/ScssConverter.js
@@ -38,7 +38,7 @@ qx.Class.define("qx.tool.compiler.resources.ScssConverter", {
     
     getDestFilename(target, asset) {
       let filename;
-      if (asset.isThemeFile()) {
+      if (!qx.tool.compiler.resources.ScssConverter.isNewCompiler()) {
         filename = path.join(target.getOutputDir(), "resource", asset.getFilename().replace(/\bscss\b/g, "css"));
       } else {
         filename = path.join(target.getOutputDir(), "resource", asset.getFilename().replace(/\.scss$/, ".css"));
@@ -47,7 +47,7 @@ qx.Class.define("qx.tool.compiler.resources.ScssConverter", {
     },
     
     async convert(target, asset, srcFilename, destFilename) {
-      if (asset.isThemeFile()) {
+      if (!qx.tool.compiler.resources.ScssConverter.isNewCompiler()) {
         return this.legacyMobileSassConvert(target, asset, srcFilename, destFilename);
       }
       
@@ -77,5 +77,19 @@ qx.Class.define("qx.tool.compiler.resources.ScssConverter", {
       await fs.writeFileAsync(destFilename, result.css);
       await fs.writeFileAsync(destFilename + ".map", result.map);
     }
+  },
+  
+  statics:{
+    USE_V6_COMPILER: null,
+    
+    isNewCompiler() {
+      if (qx.tool.compiler.resources.ScssConverter.USE_V6_COMPILER === null) {
+        console.warn("DEPRECATED: Using the Qooxdoo v5 style of SASS Compilation; this is backwards compatible " +
+            "but the default will change in v7 to use the new style (see https://git.io/fjyqj for details, and how " +
+            "to disable this warning).");
+        qx.tool.compiler.resources.ScssConverter.USE_V6_COMPILER = false;
+      }
+      return qx.tool.compiler.resources.ScssConverter.USE_V6_COMPILER;
+    },
   }
 });

--- a/source/class/qx/tool/compiler/resources/ScssConverter.js
+++ b/source/class/qx/tool/compiler/resources/ScssConverter.js
@@ -80,7 +80,7 @@ qx.Class.define("qx.tool.compiler.resources.ScssConverter", {
   },
   
   statics:{
-    USE_V6_COMPILER: null,
+    USE_V6_COMPILER: true, // Default is true for the API, the CLI will set this to null
     
     isNewCompiler() {
       if (qx.tool.compiler.resources.ScssConverter.USE_V6_COMPILER === null) {

--- a/source/class/qx/tool/compiler/resources/ScssConverter.js
+++ b/source/class/qx/tool/compiler/resources/ScssConverter.js
@@ -90,6 +90,6 @@ qx.Class.define("qx.tool.compiler.resources.ScssConverter", {
         qx.tool.compiler.resources.ScssConverter.USE_V6_COMPILER = false;
       }
       return qx.tool.compiler.resources.ScssConverter.USE_V6_COMPILER;
-    },
+    }
   }
 });

--- a/source/class/qx/tool/compiler/targets/Target.js
+++ b/source/class/qx/tool/compiler/targets/Target.js
@@ -371,13 +371,15 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
           
           function addExternal(arr, type) {
             if (arr) {
-              arr.forEach(path => {
-                if (path.match(/^https?:/)) {
-                  configdata[type].push("__external__:" + path);
+              arr.forEach(filename => {
+                if (filename.match(/^https?:/)) {
+                  configdata[type].push("__external__:" + filename);
                 } else {
-                  let lib = rm.findLibraryForResource(path);
-                  if (lib) {
-                    configdata[type].push(lib.getNamespace() + ":" + path);
+                  let asset = rm.getAsset(filename);
+                  if (asset) {
+                    let str = asset.getDestFilename(t);
+                    str = path.relative(path.join(t.getOutputDir(), "resource"), str);
+                    configdata[type].push(asset.getLibrary().getNamespace() + ":" + str);
                   }
                 }
               });
@@ -491,7 +493,7 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
                 }),
 
                 new qx.Promise((resolve, reject) => {
-                  var assetUris = application.getAssetUris(rm, configdata.environment);
+                  var assetUris = application.getAssetUris(t, rm, configdata.environment);
                   var assets = rm.getAssetsForPaths(assetUris);
                   compileInfo.assets = assets;
 

--- a/source/resource/qx/tool/schema/Manifest-1-0-0.json
+++ b/source/resource/qx/tool/schema/Manifest-1-0-0.json
@@ -206,7 +206,7 @@
           "uniqueItems": true,
           "items": {
             "type": "string",
-            "pattern": "[.]css$"
+            "pattern": "[.]s?css$"
           }
         },
         "script": {

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -35,6 +35,17 @@
         }
       }
     },
+    "sass": {
+      "type": "object",
+      "additionalItems": false,
+      "properties": {
+        "compiler": {
+          "description": "Which SASS compiler to use (default is deprecated \"legacy\" during v6, will default to \"latest\" in v7)",
+          "type": "string",
+          "pattern": "^(legacy|latest)$"
+        }
+      }
+    },
     "applications": {
       "type":"array",
       "description": "Each entry describes an application to be compiled.",

--- a/test/test-deps.js
+++ b/test/test-deps.js
@@ -258,8 +258,6 @@ test("Checks dependencies and environment settings", assert => {
        * Test SCSS generation
        */
       .then(async () => {
-        let src = await readFile("unit-tests-output/resource/testapp/css/sample.css", "utf8");
-        assert.ok(src.match(/background-color:red/), "Theme SCSS");
         src = await readFile("unit-tests-output/resource/testapp/scss/root.css", "utf8");
         assert.ok(src.match(/url\(\.\.\/sub5\/image.png\)/), "Resource SCSS");
       })

--- a/test/testapp/compile.json
+++ b/test/testapp/compile.json
@@ -126,5 +126,8 @@
   "serve": {
     "listenPort": 9082
   },
+  "sass": {
+    "compiler": "latest"
+  },
   "$schema": "https://raw.githubusercontent.com/qooxdoo/qooxdoo-compiler/master/resource/schema/v1/compile.json"
 }


### PR DESCRIPTION
This changes the SASS compiler so that it is either the old-style or the new-style, globally.  By default it is old-style but if not explicitly chosen then the first compilation will issue a deprecated warning.  The idea is that in v7 the old style will disappear.

compile.json now supports `sass.compiler` which can be "legacy" (to suppress that deprecated warning) or "latest" to switch on the new style.

This also sneaks in a couple of other warning fixes