### PR TITLE
fix for Cannot find asset qx:qx/icon/Tango/22/actions/dialog-cancel.png referenced in qxl.demobrowser:qxl/demobrowser/demo/test/combined/icons22.meta

### DIFF
--- a/source/class/qx/tool/compiler/resources/Manager.js
+++ b/source/class/qx/tool/compiler/resources/Manager.js
@@ -231,7 +231,11 @@ qx.Class.define("qx.tool.compiler.resources.Manager", {
         let fileInfo = asset.getFileInfo();
         if (fileInfo.meta) {
           for (var altPath in fileInfo.meta) {
-            let otherAsset = this.__assets[asset.getLibrary().getNamespace() + ":" + altPath];
+            let lib = this.findLibraryForResource(altPath);
+            if (!lib) {
+              lib = asset.getLibrary();
+            }
+            let otherAsset = this.__assets[lib.getNamespace() + ":" + altPath];
             if (otherAsset) {
               otherAsset.addMetaReferee(asset);
               asset.addMetaReferTo(otherAsset);


### PR DESCRIPTION
if resource is living in another library like
	"qx/icon/Tango/22/actions/dialog-ok.png": [
		22,
		22,
		"png",
		"qxl/demobrowser/demo/test/combined/icons22.png",
		0,
		0
	],

it will be not not found with  asset.getLibrary();
Therefore try this.findLibraryForResource(altPath); first