### PR TITLE
Add a "description" property to the "target" object in compile.json

### DIFF
--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -151,6 +151,10 @@
             "description": "Either `source`, `build`, or a class name in qooxdoo-compiler; using a class name is advanced usage, but ultimately the standard names just shortcuts to class names anyway (`source` is `qx.tool.compiler.targets.SourceTarget`, etc)",
             "type": "string"
           },
+          "description": {
+            "description": "A description of the target's function.",
+            "type": "string"
+          },
           "application-types": {
             "description": "The application types which this target supports",
             "type": "array",


### PR DESCRIPTION
This is useful when you have more than the standard "source" and "build" targets and you want to explain the target's function in the source code.