### PR TITLE
removes the warning "fs.promises API is experimental" without needing to start a child process

### DIFF
--- a/qx
+++ b/qx
@@ -1,8 +1,4 @@
 #!/usr/bin/env node
-const spawnSync = require("child_process").spawnSync;
-const process = require("process");
-spawnSync(`node --no-warnings ${__dirname}/main.js`, process.argv.slice(2), {
-  shell: true,
-  stdio: "inherit",
-  windowsHide: true
-});
+
+require("./index");
+new qx.tool.cli.Cli().run();

--- a/source/class/qx/tool/utils/Promisify.js
+++ b/source/class/qx/tool/utils/Promisify.js
@@ -27,7 +27,7 @@ const PromisePool = require("es6-promise-pool");
 qx.Class.define("qx.tool.utils.Promisify", {
   statics: {
     MAGIC_KEY: "__isPromisified__",
-    IGNORED_PROPS: /^(?:length|name|arguments|caller|callee|prototype|__isPromisified__)$/,
+    IGNORED_PROPS: /^(?:promises|length|name|arguments|caller|callee|prototype|__isPromisified__)$/,
 
     promisifyAll: function(target, fn) {
       Object.getOwnPropertyNames(target).forEach(key => {


### PR DESCRIPTION


fixes https://github.com/qooxdoo/qooxdoo-compiler/issues/549
see also https://github.com/qooxdoo/qooxdoo-compiler/pull/550 and https://github.com/qooxdoo/qooxdoo-compiler/pull/551