### PR TITLE
Add a manifest.json/applications[].standalone property

### DIFF
--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -349,10 +349,10 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           Object.values(this.__libraries).forEach(lib => qx.tool.compiler.Console.log(`   ${lib.getNamespace()} (${lib.getRootDir()})`));
         }
       });
-      
+
       await this._loadConfigAndStartMaking();
     },
-    
+
     async _loadConfigAndStartMaking() {
       var config = this.__config = await this.parse(this.argv);
       if (!config) {
@@ -606,7 +606,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           qx.tool.compiler.Console.print("qx.tool.cli.compile.unusedTarget", targetConfig.type, targetConfig.index);
           return;
         }
-        let appConfigs = targetConfig.appConfigs.filter(appConfig => 
+        let appConfigs = targetConfig.appConfigs.filter(appConfig =>
           !appConfig.name || !argvAppNames || qx.lang.Array.contains(argvAppNames, appConfig.name));
         if (!appConfigs.length) {
           return;
@@ -722,7 +722,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           var app = appConfig.app = new qx.tool.compiler.app.Application(appConfig["class"]);
           app.setTemplatePath(t.getTemplateDir());
 
-          [ "type", "theme", "name", "environment", "outputPath", "bootPath", "loaderTemplate"].forEach(name => {
+          [ "type", "theme", "name", "environment", "outputPath", "bootPath", "loaderTemplate", "publish", "standalone"].forEach(name => {
             if (appConfig[name] !== undefined) {
               var fname = "set" + qx.lang.String.firstUp(name);
               app[fname](appConfig[name]);

--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -103,15 +103,15 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       let apps = [];
       let defaultMaker = null;
       let firstMaker = null;
-      makers.forEach(maker => { 
+      makers.forEach(maker => {
         maker.getApplications().forEach(app => {
           if (app.isBrowserApp()) {
-            apps.push(app); 
+            apps.push(app);
             if (firstMaker === null) {
               firstMaker = maker;
             }
-            if ((defaultMaker === null) && app.getWriteIndexHtmlToRoot()) {                  
-              defaultMaker = maker;  
+            if ((defaultMaker === null) && app.getWriteIndexHtmlToRoot()) {
+              defaultMaker = maker;
             }
           }
         });
@@ -119,7 +119,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       if (!defaultMaker && (apps.length === 1)) {
         defaultMaker = firstMaker;
       }
-      
+
       let showStartpage = this.argv.showStartpage;
       if (showStartpage === null) {
         showStartpage = apps.length > 1;
@@ -133,8 +133,8 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       } else {
         let s = await this.getAppQxPath();
         if (!await fs.existsAsync(path.join(s, "docs"))) {
-          s = path.dirname(s);        
-        }   
+          s = path.dirname(s);
+        }
         app.use("/docs", express.static(path.join(s, "docs")));
         app.use("/apps", express.static(path.join(s, "apps")));
         app.use("/", express.static(website.getTargetDir()));
@@ -148,7 +148,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
               outputDir: "/" + target.getOutputDir()
             },
             apps: maker.getApplications()
-              .filter(app => app.isBrowserApp())
+              .filter(app => app.isBrowserApp() && app.getStandalone())
               .map(app => ({
                 name: app.getName(),
                 type: app.getType(),

--- a/source/class/qx/tool/compiler/app/Application.js
+++ b/source/class/qx/tool/compiler/app/Application.js
@@ -129,7 +129,7 @@ qx.Class.define("qx.tool.compiler.app.Application", {
     },
 
     /**
-     * template path 
+     * template path
      */
     templatePath: {
       init: "",
@@ -137,6 +137,24 @@ qx.Class.define("qx.tool.compiler.app.Application", {
       check: "String",
       apply: "_applyType"
 
+    },
+
+    /**
+     * Whether this app is to be published (e.g. in the PackageBrowser).
+     * Default is true.
+     */
+    publish: {
+      type: "Boolean",
+      init: true
+    },
+
+    /**
+     * Whether this app can run on its own (true, default) or is part of another
+     * application (false)
+     */
+    standalone: {
+      type: "Boolean",
+      init: true
     },
 
 
@@ -203,7 +221,7 @@ qx.Class.define("qx.tool.compiler.app.Application", {
     __fatalCompileErrors: null,
     __classes: null,
     __partsDeps: null,
-    
+
     /**
      * Checks if the application is for browser
      *
@@ -526,7 +544,7 @@ qx.Class.define("qx.tool.compiler.app.Application", {
             if (pos > -1) {
               var ns = asset.substring(0, pos);
               if (analyser.findLibrary(ns)) {
-                requiredLibs[ns] = true; 
+                requiredLibs[ns] = true;
               }
             }
           });
@@ -804,7 +822,7 @@ qx.Class.define("qx.tool.compiler.app.Application", {
                   }
                 }
               });
-          } 
+          }
           var postfix = name.substring(pos + 1);
           if (postfix) {
             t.getAnalyser().getLibraries()

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -83,6 +83,11 @@
             "type": "boolean",
             "default": true
           },
+          "standalone": {
+            "description": "Whether to hide this application can be opened in a browser on its own (true) or is part of a different application (false)",
+            "type": "boolean",
+            "default": true
+          },
           "environment": {
             "$ref": "#/properties/environment"
            },

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -84,7 +84,7 @@
             "default": true
           },
           "standalone": {
-            "description": "Whether to hide this application can be opened in a browser on its own (true) or is part of a different application (false)",
+            "description": "Whether this application can be opened in a browser on its own (true) or is part of a different application (false)",
             "type": "boolean",
             "default": true
           },


### PR DESCRIPTION
This allows `qx serve` to only disply applications that can be run in the browser on their own, and hide those which are, for example, opened by standalone apps in native windows, and require previous configuration.