### PR TITLE
fixes a bug in parsing jsdoc

### DIFF
--- a/source/class/qx/tool/cli/ConfigDb.js
+++ b/source/class/qx/tool/cli/ConfigDb.js
@@ -25,7 +25,7 @@ const path = require("path");
 qx.Class.define("qx.tool.cli.ConfigDb", {
   extend: qx.core.Object,
   
-  construct() {
+  construct: function() {
     this.base(arguments);
     this.__overrides = {};
   },

--- a/source/class/qx/tool/compiler/jsdoc/Parser.js
+++ b/source/class/qx/tool/compiler/jsdoc/Parser.js
@@ -94,7 +94,7 @@ qx.Class.define("qx.tool.compiler.jsdoc.Parser", {
       var result = {};
       cmds.forEach(function(cmd) {
         // If the body is surrounded by parameters, remove them
-        var m = cmd.body.match(/^\s*\(([\s\S]*)\)\s*$/);
+        var m = cmd.body.match(/^\s*\(([\s\S]*)\)\s*$/m);
         if (m) {
           cmd.body = m[1];
         }

--- a/source/class/qx/tool/compiler/resources/ScssFile.js
+++ b/source/class/qx/tool/compiler/resources/ScssFile.js
@@ -36,7 +36,7 @@ const nodeSass = require("node-sass");
 qx.Class.define("qx.tool.compiler.resources.ScssFile", {
   extend: qx.core.Object,
   
-  construct(target, library, filename) {
+  construct: function(target, library, filename) {
     this.base(arguments);
     this.__library = library;
     this.__filename = filename;

--- a/source/class/qx/tool/compiler/targets/SourceCodeCopier.js
+++ b/source/class/qx/tool/compiler/targets/SourceCodeCopier.js
@@ -42,7 +42,7 @@ qx.Class.define("qx.tool.compiler.targets.SourceCodeCopier", {
    * Constructor
    * @param outputFilename {String} the destination file for combined output
    */
-  construct(outputFilename) {
+  construct: function(outputFilename) {
     this.base(arguments);
 
     let pos = outputFilename.lastIndexOf(".");

--- a/source/class/qx/tool/utils/Website.js
+++ b/source/class/qx/tool/utils/Website.js
@@ -46,7 +46,7 @@ qx.Class.define("qx.tool.utils.Website", {
     TARGET_DIR: path.join(qx.tool.$$resourceDir, "website/build")
   },
 
-  construct(options={}) {
+  construct: function(options={}) {
     qx.core.Object.apply(this, arguments);
     const self = qx.tool.utils.Website;
     this.initSourceDir(self.SOURCE_DIR);

--- a/source/class/qx/tool/utils/json/Tokenizer.js
+++ b/source/class/qx/tool/utils/json/Tokenizer.js
@@ -51,7 +51,7 @@ const __tokenTypes = {
 qx.Class.define("qx.tool.utils.json.Tokenizer", {
   extend: qx.core.Object,
   
-  construct(input, settings) {
+  construct: function(input, settings) {
     this.base(arguments);
     this.input = input;
     this.settings = settings||{};

--- a/source/class/qx/tool/utils/json/Writer.js
+++ b/source/class/qx/tool/utils/json/Writer.js
@@ -26,7 +26,7 @@
 qx.Class.define("qx.tool.utils.json.Writer", {
   extend: qx.core.Object,
   
-  construct() {
+  construct: function() {
     this.base(arguments);
     this.buffer = "";
     this.__indent = 0;


### PR DESCRIPTION
fixes a bug in parsing jsdoc, where the last compiler hint won't be parsed properly if there is anything on the next line