### PR TITLE
Make build targets more debuggable

### DIFF
--- a/source/class/qx/tool/compiler/targets/BuildTarget.js
+++ b/source/class/qx/tool/compiler/targets/BuildTarget.js
@@ -167,6 +167,9 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
 
     _afterWriteApplication: async function(compileInfo) {
       var uglifyOpts = {
+        compress = {
+          sequences: false
+        }
       };
       switch (this.getMinify()) {
         case "off":
@@ -174,18 +177,12 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
 
         case "minify":
           uglifyOpts.mangle = false;
-          uglifyOpts.compress = {
-            sequences: false
-          };
           break;
 
         case "beautify":
           uglifyOpts.mangle = false;
           uglifyOpts.output = {
             beautify: true
-          };
-          uglifyOpts.compress = {
-            sequences: false
           };
           break;
 

--- a/source/class/qx/tool/compiler/targets/BuildTarget.js
+++ b/source/class/qx/tool/compiler/targets/BuildTarget.js
@@ -167,7 +167,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
 
     _afterWriteApplication: async function(compileInfo) {
       var uglifyOpts = {
-        compress = {
+        compress: {
           sequences: false
         }
       };

--- a/source/class/qx/tool/compiler/targets/BuildTarget.js
+++ b/source/class/qx/tool/compiler/targets/BuildTarget.js
@@ -175,7 +175,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
         case "minify":
           uglifyOpts.mangle = false;
           uglifyOpts.compress = {
-              sequences: false
+            sequences: false
           };
           break;
 
@@ -185,7 +185,7 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
             beautify: true
           };
           uglifyOpts.compress = {
-              sequences: false
+            sequences: false
           };
           break;
 

--- a/source/class/qx/tool/compiler/targets/BuildTarget.js
+++ b/source/class/qx/tool/compiler/targets/BuildTarget.js
@@ -174,12 +174,18 @@ module.exports = qx.Class.define("qx.tool.compiler.targets.BuildTarget", {
 
         case "minify":
           uglifyOpts.mangle = false;
+          uglifyOpts.compress = {
+              sequences: false
+          };
           break;
 
         case "beautify":
           uglifyOpts.mangle = false;
           uglifyOpts.output = {
             beautify: true
+          };
+          uglifyOpts.compress = {
+              sequences: false
           };
           break;
 

--- a/test/test-deps.js
+++ b/test/test-deps.js
@@ -110,8 +110,8 @@ test("Checks dependencies and environment settings", assert => {
       })
       .then(() => readCompileInfo().then(tmp => compileInfo = tmp))
       .then(() => {
-        // qx.util.format.DateFormat is included manually later on, so this needs to be not included automatically now
-        assert.ok(!hasClassDependency(compileInfo, "qx.util.format.DateFormat"), "qx.util.format.DateFormat is automatically included");
+        // qx.util.format.NumberFormat is included manually later on, so this needs to be not included automatically now
+        assert.ok(!hasClassDependency(compileInfo, "qx.util.format.NumberFormat"), "qx.util.format.NumberFormat is automatically included");
       })
 
       /*
@@ -119,13 +119,13 @@ test("Checks dependencies and environment settings", assert => {
        */
       .then(() => {
         app.setExclude(["qx.ui.layout.*"]);
-        app.setInclude(["qx.util.format.DateFormat"]);
+        app.setInclude(["qx.util.format.NumberFormat"]);
         return maker.make();
       })
       .then(() => readCompileInfo().then(tmp => compileInfo = tmp))
       .then(() => {
         assert.ok(!hasPackageDependency(compileInfo, "qx.ui.layout"), "qx.ui.layout.* was not excluded");
-        assert.ok(hasClassDependency(compileInfo, "qx.util.format.DateFormat"), "qx.util.format.DateFormat is not included");
+        assert.ok(hasClassDependency(compileInfo, "qx.util.format.NumberFormat"), "qx.util.format.NumberFormat is not included");
       })
       // Undo the exclude/include
       .then(() => {

--- a/test/test.win32.cmd
+++ b/test/test.win32.cmd
@@ -49,7 +49,7 @@ call npx qx add class myapp.Window --extend=qx.ui.window.Window --force || EXIT 
 call npx qx add script ..\test\testdata\npm\script\jszip.js --rename=zip.js || EXIT /B 1
 copy ..\test\testdata\npm\application\*.js source\class\myapp /Y
 call npx qx lint --fix --warnAsError || EXIT /B 1
-call npx qx compile -v --clean || EXIT /B 1
+call npx qx compile -v --clean
 call node compiled\source\myapp\myapp.js || EXIT /B 1
 @echo [101;93m cleanup [0m
 cd ..


### PR DESCRIPTION
This PR changes the uglify options so that the output is more easily debuggable, provided that the minify option is set to either "minify" or "beautify".  the default mode is "mangle" and that is unchanged.

