### PR TITLE
NodeJS DOM Emulation

### DIFF
--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -21,7 +21,6 @@ const process = require("process");
 const express = require("express");
 const http = require("http");
 const fs = qx.tool.utils.Promisify.fs;
-const chokidar = require("chokidar");
 
 require("app-module-path").addPath(process.cwd() + "/node_modules");
 

--- a/source/class/qx/tool/utils/Website.js
+++ b/source/class/qx/tool/utils/Website.js
@@ -128,15 +128,16 @@ qx.Class.define("qx.tool.utils.Website", {
      * @return {Boolean} true if its running
      */
     isWatching() {
-      return !!this._watcher;
+      return Boolean(this._watcher);
     },
 
     /**
      * Waits for the rebuild process to complete, if it is running
      */
     async waitForRebuildComplete() {
-      if (this.__rebuildPromise)
+      if (this.__rebuildPromise) {
         await this.__rebuildPromise;
+      }
     },
     
     /**
@@ -193,7 +194,7 @@ qx.Class.define("qx.tool.utils.Website", {
         } finally {
           this.__rebuilding = false;
         }
-      }
+      };
       
       if (this.__rebuildTimer) {
         clearTimeout(this.__rebuildTimer);

--- a/source/class/qx/tool/utils/Website.js
+++ b/source/class/qx/tool/utils/Website.js
@@ -30,6 +30,7 @@ const markdown = require("metalsmith-markdown");
 //const filenames = require("metalsmith-filenames");
 //var permalinks = require("metalsmith-permalinks");
 const sass = require("node-sass");
+const chokidar = require("chokidar");
 
 // config
 dot.templateSettings.strip = false;
@@ -76,7 +77,131 @@ qx.Class.define("qx.tool.utils.Website", {
   },
 
   members: {
+    /** @type {chokidar} watcher */
+    __watcher: null,
+    
+    /** @type {Boolean} whether the watcher is ready yet */
+    __watcherReady: false,
+    
+    /** @type {Integer} setTimeout timer ID for debouncing builds */
+    __rebuildTimer: null,
+    
+    /** @type {Boolean} Whether the build is currently taking place */
+    __rebuilding: false,
+    
+    /** @type {Boolean} Whether a rebuild is needed ASAP */
+    __needsRebuild: false,
+    
+    /**
+     * Starts the watcher for files in the source directory and compiles as needed
+     */
+    async startWatcher() {
+      await this.stopWatcher();
+      let sourceDir = await qx.tool.utils.files.Utils.correctCase(this.getSourceDir());
+      this._watcher = chokidar.watch([ sourceDir ], {});
+      this._watcher.on("change", filename => this.__onFileChange("change", filename));
+      this._watcher.on("add", filename => this.__onFileChange("add", filename));
+      this._watcher.on("unlink", filename => this.__onFileChange("unlink", filename));
+      this._watcher.on("ready", async () => {
+        await this.triggerRebuild(true);
+        this.__watcherReady = true;
+      });
+      this._watcher.on("error", err => {
+        qx.tool.compiler.Console.print(err.code == "ENOSPC" ? "qx.tool.cli.watch.enospcError" : "qx.tool.cli.watch.watchError", err);
+      });
+    },
 
+    /**
+     * Stops the watcher, if its running
+     */
+    async stopWatcher() {
+      if (this._watcher) {
+        await this._watcher.stop();
+        this._watcher = null;
+        this.__watcherReady = false;
+      }
+    },
+    
+    /**
+     * Whether the watcher is running
+     * 
+     * @return {Boolean} true if its running
+     */
+    isWatching() {
+      return !!this._watcher;
+    },
+
+    /**
+     * Waits for the rebuild process to complete, if it is running
+     */
+    async waitForRebuildComplete() {
+      if (this.__rebuildPromise)
+        await this.__rebuildPromise;
+    },
+    
+    /**
+     * Rebuilds everything needed for the website
+     */
+    async rebuildAll() {
+      await this.generateSite();
+      await this.compileScss();
+    },
+
+    /**
+     * Event handler for changes to the source files
+     * 
+     * @param type {String} type of change, one of "change", "add", "unlink"
+     * @param filename {String} the file that changed
+     */
+    __onFileChange(type, filename) {
+      if (this.__watcherReady) {
+        if (!filename.toLowerCase().startsWith(this.getTargetDir().toLowerCase())) {
+          this.triggerRebuild(false);
+        }
+      }
+    },
+    
+    /**
+     * Triggers a rebuild of the website, asynchronously.  Unless immediate is true,
+     * the rebuild will only happen after a short delay; but each time this is called,
+     * the delay is restarted.  This is to allow multiple files to be changed without
+     * swamping the processor with compilations.
+     * 
+     * @param immediate {Boolean?} if true, rebuild starts ASAP
+     */
+    triggerRebuild(immediate) {
+      if (this.__rebuilding) {
+        this.__needsRebuild = true;
+        return;
+      }
+      
+      let rebuilderImpl = async () => {
+        await this.rebuildAll();
+        
+        if (this.__needsRebuild) {
+          this.__needsRebuild = false;
+          await rebuilderImpl();
+        }
+      };
+      
+      let rebuilder = async () => {
+        this.__rebuilding = true;
+        try {
+          this.__rebuildPromise = rebuilderImpl();
+          await this.__rebuildPromise;
+          this.__rebuildPromise = null;
+        } finally {
+          this.__rebuilding = false;
+        }
+      }
+      
+      if (this.__rebuildTimer) {
+        clearTimeout(this.__rebuildTimer);
+        this.__rebuildTimer = null;
+      }
+      this.__rebuildTimer = setTimeout(rebuilder, immediate ? 1 : 250);
+    },
+    
     /**
      * Metalsmith Plugin that collates a list of pages that are to be included in the site navigation
      * into the metadata, along with their URLs.

--- a/source/resource/qx/tool/cli/templates/loader/loader-node.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/loader/loader-node.tmpl.js
@@ -4,33 +4,6 @@
   
   if (typeof window === "undefined") 
     window = this;
-
-  // Node suppresses output to the "real" console when calling console.debug, it's only shown
-  //  in the debugger 
-  console.debug = function() {
-    var args = [].slice.apply(arguments);
-    console.log.apply(this, args);
-  };
-
-  window.document = document = {
-      readyState: "ready",
-      createEvent: function() {
-        return {
-          initCustomEvent: function() {}
-        };
-      },
-      createElement: function () {
-		  return {}
-	  },
-      addListener: function() {},
-      removeListener: function() {},
-      documentElement: {
-        style: {}
-      }
-  };
-
-  if (!this.window) 
-    window = this;
   window.dispatchEvent = function() {};
 
   if (!window.navigator) window.navigator = {};
@@ -39,6 +12,45 @@
   }
   if (!window.navigator.product) window.navigator.product = "";
   if (!window.navigator.cpuClass) window.navigator.cpuClass = "";
+
+  // Node suppresses output to the "real" console when calling console.debug, it's only shown
+  //  in the debugger 
+  console.debug = function() {
+    var args = [].slice.apply(arguments);
+    console.log.apply(this, args);
+  };
+  
+  var JSDOM = null;
+  try {
+    JSDOM = require("jsdom").JSDOM;
+  } catch(ex) {
+    // Nothing
+  }
+  if (JSDOM) {
+    var dom = new JSDOM(`<!DOCTYPE html><html><head></head><body></body></html>`);
+    if (!window)
+      window = dom.window;
+    else {
+      window.document = dom.window.document;
+    }
+  } else {
+    window.document = document = {
+        readyState: "ready",
+        createEvent: function() {
+          return {
+            initCustomEvent: function() {}
+          };
+        },
+        createElement: function () {
+          return {}
+        },
+        addListener: function() {},
+        removeListener: function() {},
+        documentElement: {
+          style: {}
+        }
+    };
+  }
 
   if (!this.qxloadPrefixUrl)
     qxloadPrefixUrl = "";

--- a/source/resource/qx/tool/website/build/404.html
+++ b/source/resource/qx/tool/website/build/404.html
@@ -7,19 +7,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="assets/bootstrap.min.css">
-    <link rel="stylesheet" href="assets/abel.css" >
-    <link rel="icon" href="assets/favicon.png" type="image/png">
+    <link rel="stylesheet" href="/assets/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/abel.css" >
+    <link rel="icon" href="/assets/favicon.png" type="image/png">
 
     <!-- Github buttons -->
-    <script src="assets/buttons.js"></script>
-    <script src="assets/fontawesome-all.js"></script>
+    <script src="/assets/buttons.js"></script>
+    <script src="/assets/fontawesome-all.js"></script>
 
     <title>Qooxdoo Application Server</title>
     <meta name="description" content="">
     <link rel="stylesheet" type="text/css" href="/qooxdoo.css">
-    <script type="text/javascript" src="assets/bluebird.min.js"></script>
-    <script type="text/javascript" src="assets/jquery.js"></script>
+    <script type="text/javascript" src="/assets/bluebird.min.js"></script>
+    <script type="text/javascript" src="/assets/jquery.js"></script>
     <script type="text/javascript" src="/scripts/serve.js"></script>
 </head>
 
@@ -29,7 +29,7 @@
         <div class="container-fluid pt-0">
       <nav class="navbar fixed-top navbar-expand-sm pl-1" id="navigatopnBar">
         <a class="navbar-brand invisible" href="#" style="width: 0" id="navigationLogo">
-          <img src="assets/logo.svg" width="auto" height="30" alt="">
+          <img src="/assets/logo.svg" width="auto" height="30" alt="">
         </a>
         <button class="navbar-toggler navbar-dark" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -74,7 +74,7 @@
          background-color:#002838;
          background-size:8px 8px;
          box-shadow: inset 0 -10px 25px -10px #000000;">
-      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="assets/logo.svg">
+      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="/assets/logo.svg">
       <h3 class="text-white text-center pb-5 d-none d-sm-block" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h3>
       <h5 class="text-white text-center pb-5 d-block d-sm-none" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h5>
     </div>
@@ -197,11 +197,11 @@
         </div>
       </div>
       <div class="container text-center d-none d-sm-block p-4">
-        <img class="img p-4" src="assets/qx-white.svg">
+        <img class="img p-4" src="/assets/qx-white.svg">
         <span class="text-light">&copy; 2005-2018 Qooxdoo Contributors</span>
       </div>
       <div class="container text-center d-block d-sm-none p-4">
-        <img class="img-fluid p-4" src="assets/qx-white.svg">
+        <img class="img-fluid p-4" src="/assets/qx-white.svg">
         <p>&copy; 2005-2017 Qooxdoo Contributors</p>
       </div>
     </div>

--- a/source/resource/qx/tool/website/build/about.html
+++ b/source/resource/qx/tool/website/build/about.html
@@ -7,19 +7,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="assets/bootstrap.min.css">
-    <link rel="stylesheet" href="assets/abel.css" >
-    <link rel="icon" href="assets/favicon.png" type="image/png">
+    <link rel="stylesheet" href="/assets/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/abel.css" >
+    <link rel="icon" href="/assets/favicon.png" type="image/png">
 
     <!-- Github buttons -->
-    <script src="assets/buttons.js"></script>
-    <script src="assets/fontawesome-all.js"></script>
+    <script src="/assets/buttons.js"></script>
+    <script src="/assets/fontawesome-all.js"></script>
 
     <title>About</title>
     <meta name="description" content="">
     <link rel="stylesheet" type="text/css" href="/qooxdoo.css">
-    <script type="text/javascript" src="assets/bluebird.min.js"></script>
-    <script type="text/javascript" src="assets/jquery.js"></script>
+    <script type="text/javascript" src="/assets/bluebird.min.js"></script>
+    <script type="text/javascript" src="/assets/jquery.js"></script>
     <script type="text/javascript" src="/scripts/serve.js"></script>
 </head>
 
@@ -29,7 +29,7 @@
         <div class="container-fluid pt-0">
       <nav class="navbar fixed-top navbar-expand-sm pl-1" id="navigatopnBar">
         <a class="navbar-brand invisible" href="#" style="width: 0" id="navigationLogo">
-          <img src="assets/logo.svg" width="auto" height="30" alt="">
+          <img src="/assets/logo.svg" width="auto" height="30" alt="">
         </a>
         <button class="navbar-toggler navbar-dark" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -74,7 +74,7 @@
          background-color:#002838;
          background-size:8px 8px;
          box-shadow: inset 0 -10px 25px -10px #000000;">
-      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="assets/logo.svg">
+      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="/assets/logo.svg">
       <h3 class="text-white text-center pb-5 d-none d-sm-block" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h3>
       <h5 class="text-white text-center pb-5 d-block d-sm-none" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h5>
     </div>
@@ -180,11 +180,11 @@
         </div>
       </div>
       <div class="container text-center d-none d-sm-block p-4">
-        <img class="img p-4" src="assets/qx-white.svg">
+        <img class="img p-4" src="/assets/qx-white.svg">
         <span class="text-light">&copy; 2005-2018 Qooxdoo Contributors</span>
       </div>
       <div class="container text-center d-block d-sm-none p-4">
-        <img class="img-fluid p-4" src="assets/qx-white.svg">
+        <img class="img-fluid p-4" src="/assets/qx-white.svg">
         <p>&copy; 2005-2017 Qooxdoo Contributors</p>
       </div>
     </div>

--- a/source/resource/qx/tool/website/build/diagnostics/dependson.html
+++ b/source/resource/qx/tool/website/build/diagnostics/dependson.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="/assets/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/abel.css" >
+    <link rel="icon" href="/assets/favicon.png" type="image/png">
+
+    <!-- Github buttons -->
+    <script src="/assets/buttons.js"></script>
+    <script src="/assets/fontawesome-all.js"></script>
+
+    <title>Qooxdoo Application Server</title>
+    <meta name="description" content="">
+    <link rel="stylesheet" type="text/css" href="/qooxdoo.css">
+    <script type="text/javascript" src="/assets/bluebird.min.js"></script>
+    <script type="text/javascript" src="/assets/jquery.js"></script>
+    <script type="text/javascript" src="/scripts/serve.js"></script>
+</head>
+
+
+  <body>
+
+        <div class="container-fluid pt-0">
+      <nav class="navbar fixed-top navbar-expand-sm pl-1" id="navigatopnBar">
+        <a class="navbar-brand invisible" href="#" style="width: 0" id="navigationLogo">
+          <img src="/assets/logo.svg" width="auto" height="30" alt="">
+        </a>
+        <button class="navbar-toggler navbar-dark" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse navbar-dark" id="navbarNav">
+          <ul class="navbar-nav">
+            
+                
+                <li class="nav-item active">
+                    <a class="nav-link text-light" href="/">Home Page</a>
+                </li>
+                
+            
+                
+                <li class="nav-item active">
+                    <a class="nav-link text-light" href="about.html">About</a>
+                </li>
+                
+            
+            <li class="nav-item">
+              <a class="nav-link text-light" target="docs" href="/docs">Documentation</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link text-light" target="api" href="/apps/apiviewer">API</a>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Github star -->
+        <span class="d-none d-md-block">
+          <a class="github-button" target="github" href="https://github.com/qooxdoo/qooxdoo" data-show-count="true" aria-label="Star qooxdoo/qooxdoo on GitHub">Star</a>
+        </span>
+      </nav>
+    </div>
+
+
+    <div class="container-fluid py-5" style="background:
+         radial-gradient(black 15%, transparent 16%) 0 0,
+         radial-gradient(black 15%, transparent 16%) 4px 4px,
+         radial-gradient(rgba(0,255,169,.1) 15%, transparent 20%) 0 1px,
+         radial-gradient(rgba(0,255,169,.1) 15%, transparent 20%) 4px 5px;
+         background-color:#002838;
+         background-size:8px 8px;
+         box-shadow: inset 0 -10px 25px -10px #000000;">
+      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="/assets/logo.svg">
+      <h3 class="text-white text-center pb-5 d-none d-sm-block" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h3>
+      <h5 class="text-white text-center pb-5 d-block d-sm-none" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h5>
+    </div>
+
+
+
+
+
+    <!-- Content -->
+    <div class="container py-5">
+        
+<script src="dependson.js"></script>
+<select id="show">
+    <option value="both" selected>runtime and loadtime</option>
+    <option value="runtime">runtime</option>
+    <option value="load">load</option>
+</select>
+
+<style>
+    li {
+        cursor: pointer;
+    }
+</style>
+
+<div id="root">
+</div>
+    </div> 
+
+    
+    <!-- Footer -->
+    <div class="container-fluid py-5" style="background-color: #555; color: #BBB">
+      <div class="container py-4">
+        <div class="row">
+          <div class="col pb-5">
+            <div class="row">
+              <div class="col">
+                <h5 style="color: #EEE">About</h5>
+                <ul class="nav flex-column">
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="extern" href="https://opensource.org/licenses/MIT">License</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="extern" href="https://github.com/qooxdoo/qooxdoo">Source</a>
+                  </li>
+<!---
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" href="#">Team</a>
+                  </li>
+-->
+                </ul>
+              </div>
+              <div class="col">
+                <h5 style="color: #EEE">Learn &amp; Code</h5>
+                <ul class="nav flex-column">
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="docs" href="/docs">Documentation</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="demobrowser" href="/apps/demobrowser">Demobrowser</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="playground" href="/apps/playground">Playground</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="widgetbrowser" href="/apps/widgetbrowser">Widgetbrowser</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="mobileshowcase" href="/apps/mobileshowcase">Mobileshowcase</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="extern" href="http://www.qooxdoo.org/qxl.packagebrowser">Browse packages<span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></span></a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="extern" href="https://news.qooxdoo.org">Blog <span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></span></a>
+                  </li>
+                </ul>
+              </div>
+              <div class="col">
+                <h5 style="color: #EEE">Support</h5>
+                <ul class="nav flex-column">
+                  <li class="nav-item">
+                    <a class="nav-link p-0 text-nowrap" style="color: #BBB" target="extern" href="https://github.com/qooxdoo/qooxdoo/issues">GitHub Issues <span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></span></a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0 text-nowrap" style="color: #BBB" target="extern" href="https://gitter.im/qooxdoo/qooxdoo">Chat on Gitter <span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0 text-nowrap" style="color: #BBB" target="extern" href=""https://stackoverflow.com/questions/tagged/qooxdoo>Q/A <span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" href="#">FAQ</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="col-md text-center pb-5">
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://github.com/qooxdoo/qooxdoo" data-original-title="Qooxdoo on GitHub">
+              <i class="fab fa-2x fa-github mx-1"></i>
+            </a>
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://gitter.im/qooxdoo/qooxdoo" data-original-title="Chat with us on Gitter">
+              <i class="fab fa-2x fa-gitter mx-1"></i>
+            </a>
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://news.qooxdoo.org" data-original-title="Qooxdoo Blog">
+              <i class="fab fa-2x fa-medium mx-1"></i>
+            </a>
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://twitter.com/qooxdoo" data-original-title="Qooxdoo on Twitter">
+              <i class="fab fa-2x fa-twitter mx-1"></i>
+            </a>
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://stackoverflow.com/questions/tagged/qooxdoo" data-original-title="Qooxdoo Q/A">
+              <i class="fab fa-2x fa-stack-overflow mx-1"></i>
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="container text-center d-none d-sm-block p-4">
+        <img class="img p-4" src="/assets/qx-white.svg">
+        <span class="text-light">&copy; 2005-2018 Qooxdoo Contributors</span>
+      </div>
+      <div class="container text-center d-block d-sm-none p-4">
+        <img class="img-fluid p-4" src="/assets/qx-white.svg">
+        <p>&copy; 2005-2017 Qooxdoo Contributors</p>
+      </div>
+    </div>
+
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+        $(function () {
+          $('[data-toggle="tooltip"]').tooltip()
+        })
+        var scroll = (function (event) {
+          var scroll = $(window).scrollTop();
+          if (scroll < 250) {
+            $(navigatopnBar).css('background-color', 'transparent');
+            $(navigationLogo).css('width', '0');
+            $(navigationLogo).addClass('invisible');
+          } else {
+            $(navigatopnBar).css('background-color', 'rgba(0, 40, 56, 0.9)');
+            $(navigationLogo).css('width', '');
+            $(navigationLogo).removeClass('invisible');
+          }
+        });
+        $(window).scroll(scroll);
+        scroll();
+    </script>
+
+
+
+  </body>
+
+</html>

--- a/source/resource/qx/tool/website/build/diagnostics/dependson.js
+++ b/source/resource/qx/tool/website/build/diagnostics/dependson.js
@@ -1,0 +1,65 @@
+$(function() {
+
+  var db;
+
+  function show(name, $list) {
+    var def = db.classInfo[name];
+    if (!def || !def.dependsOn)
+      return;
+    for ( var depName in def.dependsOn) {
+      var isLoad = def.dependsOn[depName].load;
+      var $li = $("<li>").text(depName).attr("data-classname", depName);
+      if (isLoad)
+        $li.addClass("load");
+      else
+        $li.addClass("runtime");
+      $li.click(function(e) {
+        e.stopPropagation();
+        var $this = $(this), className = $this.attr("data-classname"), $ul = $("ul", this);
+        if ($ul.length) {
+          $ul.remove();
+          return;
+        }
+        var $ul = $("<ul>");
+        $this.append($ul);
+        show(className, $ul);
+        updateDisplay();
+      });
+      $list.append($li);
+    }
+  }
+
+  function selectClass(name) {
+    $("#root").append($("<h3>").text(name + " Depends On"));
+    var $root = $("<ul>");
+    $("#root").append($root);
+    show(name, $root);
+  }
+
+  function updateDisplay() {
+    var value = $("#show").val();
+    switch (value) {
+    case "runtime":
+      $(".load").hide();
+      $(".runtime").show();
+      break;
+
+    case "load":
+      $(".load").show();
+      $(".runtime").hide();
+      break;
+
+    default:
+      $(".load").show();
+      $(".runtime").show();
+      break;
+    }
+  }
+
+  $.qxcli.get($.qxcli.query.targetDir + "/db.json").then(function(tmp) {
+    db = tmp;
+    selectClass($.qxcli.query.appClass);
+    $("#show").change(updateDisplay);
+  });
+
+});

--- a/source/resource/qx/tool/website/build/diagnostics/requiredby.html
+++ b/source/resource/qx/tool/website/build/diagnostics/requiredby.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="/assets/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/abel.css" >
+    <link rel="icon" href="/assets/favicon.png" type="image/png">
+
+    <!-- Github buttons -->
+    <script src="/assets/buttons.js"></script>
+    <script src="/assets/fontawesome-all.js"></script>
+
+    <title>Qooxdoo Application Server</title>
+    <meta name="description" content="">
+    <link rel="stylesheet" type="text/css" href="/qooxdoo.css">
+    <script type="text/javascript" src="/assets/bluebird.min.js"></script>
+    <script type="text/javascript" src="/assets/jquery.js"></script>
+    <script type="text/javascript" src="/scripts/serve.js"></script>
+</head>
+
+
+  <body>
+
+        <div class="container-fluid pt-0">
+      <nav class="navbar fixed-top navbar-expand-sm pl-1" id="navigatopnBar">
+        <a class="navbar-brand invisible" href="#" style="width: 0" id="navigationLogo">
+          <img src="/assets/logo.svg" width="auto" height="30" alt="">
+        </a>
+        <button class="navbar-toggler navbar-dark" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse navbar-dark" id="navbarNav">
+          <ul class="navbar-nav">
+            
+                
+                <li class="nav-item active">
+                    <a class="nav-link text-light" href="/">Home Page</a>
+                </li>
+                
+            
+                
+                <li class="nav-item active">
+                    <a class="nav-link text-light" href="about.html">About</a>
+                </li>
+                
+            
+            <li class="nav-item">
+              <a class="nav-link text-light" target="docs" href="/docs">Documentation</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link text-light" target="api" href="/apps/apiviewer">API</a>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Github star -->
+        <span class="d-none d-md-block">
+          <a class="github-button" target="github" href="https://github.com/qooxdoo/qooxdoo" data-show-count="true" aria-label="Star qooxdoo/qooxdoo on GitHub">Star</a>
+        </span>
+      </nav>
+    </div>
+
+
+    <div class="container-fluid py-5" style="background:
+         radial-gradient(black 15%, transparent 16%) 0 0,
+         radial-gradient(black 15%, transparent 16%) 4px 4px,
+         radial-gradient(rgba(0,255,169,.1) 15%, transparent 20%) 0 1px,
+         radial-gradient(rgba(0,255,169,.1) 15%, transparent 20%) 4px 5px;
+         background-color:#002838;
+         background-size:8px 8px;
+         box-shadow: inset 0 -10px 25px -10px #000000;">
+      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="/assets/logo.svg">
+      <h3 class="text-white text-center pb-5 d-none d-sm-block" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h3>
+      <h5 class="text-white text-center pb-5 d-block d-sm-none" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h5>
+    </div>
+
+
+
+
+
+    <!-- Content -->
+    <div class="container py-5">
+        
+<script type="text/javascript" src="requiredby.js"></script>
+
+<select id="show">
+    <option value="both" selected>runtime and loadtime</option>
+    <option value="runtime">runtime</option>
+    <option value="load">load</option>
+</select>
+
+<style>
+    li {
+        cursor: pointer;
+    }
+</style>
+
+<div id="root">
+</div>
+
+
+    </div> 
+
+    
+    <!-- Footer -->
+    <div class="container-fluid py-5" style="background-color: #555; color: #BBB">
+      <div class="container py-4">
+        <div class="row">
+          <div class="col pb-5">
+            <div class="row">
+              <div class="col">
+                <h5 style="color: #EEE">About</h5>
+                <ul class="nav flex-column">
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="extern" href="https://opensource.org/licenses/MIT">License</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="extern" href="https://github.com/qooxdoo/qooxdoo">Source</a>
+                  </li>
+<!---
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" href="#">Team</a>
+                  </li>
+-->
+                </ul>
+              </div>
+              <div class="col">
+                <h5 style="color: #EEE">Learn &amp; Code</h5>
+                <ul class="nav flex-column">
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="docs" href="/docs">Documentation</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="demobrowser" href="/apps/demobrowser">Demobrowser</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="playground" href="/apps/playground">Playground</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="widgetbrowser" href="/apps/widgetbrowser">Widgetbrowser</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="mobileshowcase" href="/apps/mobileshowcase">Mobileshowcase</a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="extern" href="http://www.qooxdoo.org/qxl.packagebrowser">Browse packages<span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></span></a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" target="extern" href="https://news.qooxdoo.org">Blog <span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></span></a>
+                  </li>
+                </ul>
+              </div>
+              <div class="col">
+                <h5 style="color: #EEE">Support</h5>
+                <ul class="nav flex-column">
+                  <li class="nav-item">
+                    <a class="nav-link p-0 text-nowrap" style="color: #BBB" target="extern" href="https://github.com/qooxdoo/qooxdoo/issues">GitHub Issues <span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></span></a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0 text-nowrap" style="color: #BBB" target="extern" href="https://gitter.im/qooxdoo/qooxdoo">Chat on Gitter <span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0 text-nowrap" style="color: #BBB" target="extern" href=""https://stackoverflow.com/questions/tagged/qooxdoo>Q/A <span<i class="fas fa-external-link-alt fa-sm" data-fa-transform="up-1 shrink-5"></i></a>
+                  </li>
+                  <li class="nav-item">
+                    <a class="nav-link p-0" style="color: #BBB" href="#">FAQ</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="col-md text-center pb-5">
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://github.com/qooxdoo/qooxdoo" data-original-title="Qooxdoo on GitHub">
+              <i class="fab fa-2x fa-github mx-1"></i>
+            </a>
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://gitter.im/qooxdoo/qooxdoo" data-original-title="Chat with us on Gitter">
+              <i class="fab fa-2x fa-gitter mx-1"></i>
+            </a>
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://news.qooxdoo.org" data-original-title="Qooxdoo Blog">
+              <i class="fab fa-2x fa-medium mx-1"></i>
+            </a>
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://twitter.com/qooxdoo" data-original-title="Qooxdoo on Twitter">
+              <i class="fab fa-2x fa-twitter mx-1"></i>
+            </a>
+            <a class="btn btn-link p-0 mx-1 text-light" data-toggle="tooltip" data-placement="top" title="" target="extern" href="https://stackoverflow.com/questions/tagged/qooxdoo" data-original-title="Qooxdoo Q/A">
+              <i class="fab fa-2x fa-stack-overflow mx-1"></i>
+            </a>
+          </div>
+        </div>
+      </div>
+      <div class="container text-center d-none d-sm-block p-4">
+        <img class="img p-4" src="/assets/qx-white.svg">
+        <span class="text-light">&copy; 2005-2018 Qooxdoo Contributors</span>
+      </div>
+      <div class="container text-center d-block d-sm-none p-4">
+        <img class="img-fluid p-4" src="/assets/qx-white.svg">
+        <p>&copy; 2005-2017 Qooxdoo Contributors</p>
+      </div>
+    </div>
+
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+        $(function () {
+          $('[data-toggle="tooltip"]').tooltip()
+        })
+        var scroll = (function (event) {
+          var scroll = $(window).scrollTop();
+          if (scroll < 250) {
+            $(navigatopnBar).css('background-color', 'transparent');
+            $(navigationLogo).css('width', '0');
+            $(navigationLogo).addClass('invisible');
+          } else {
+            $(navigatopnBar).css('background-color', 'rgba(0, 40, 56, 0.9)');
+            $(navigationLogo).css('width', '');
+            $(navigationLogo).removeClass('invisible');
+          }
+        });
+        $(window).scroll(scroll);
+        scroll();
+    </script>
+
+
+
+  </body>
+
+</html>

--- a/source/resource/qx/tool/website/build/diagnostics/requiredby.js
+++ b/source/resource/qx/tool/website/build/diagnostics/requiredby.js
@@ -1,0 +1,78 @@
+$(function() {
+
+  var db;
+
+  function show(name, $list) {
+    var def = db.classInfo[name];
+    if (!def || !def.requiredBy)
+      return;
+    for ( var depName in def.requiredBy) {
+      var $li = $("<li>").text(depName).attr("data-classname", depName);
+      if (def.requiredBy[depName].load)
+        $li.addClass("load");
+      else
+        $li.addClass("runtime");
+      $li.click(function(e) {
+        e.stopPropagation();
+        var $this = $(this), className = $this.attr("data-classname"), $ul = $("ul", this);
+        if ($ul.length) {
+          $ul.remove();
+          return;
+        }
+        var $ul = $("<ul>");
+        $this.append($ul);
+        show(className, $ul);
+        updateDisplay();
+      });
+      $list.append($li);
+    }
+  }
+
+  function selectClass(name) {
+    $("#root").append($("<h3>").text(name + " Required By"));
+    var $root = $("<ul>");
+    $("#root").append($root);
+    show(name, $root);
+  }
+
+  function updateDisplay() {
+    var value = $("#show").val();
+    switch (value) {
+    case "runtime":
+      $(".load").hide();
+      $(".runtime").show();
+      break;
+
+    case "load":
+      $(".load").show();
+      $(".runtime").hide();
+      break;
+
+    default:
+      $(".load").show();
+      $(".runtime").show();
+      break;
+    }
+  }
+
+  $.qxcli.get($.qxcli.query.targetDir + "/db.json").then(function(tmp) {
+    db = tmp;
+    
+    for ( var name in db.classInfo) {
+      var def = db.classInfo[name];
+      if (def.dependsOn)
+        for ( var depName in def.dependsOn) {
+          var depDef = db.classInfo[depName];
+          if (!depDef.requiredBy)
+            depDef.requiredBy = {};
+          depDef.requiredBy[name] = {
+            load: def.dependsOn[depName].load
+          };
+        }
+      selectClass(name);
+    }
+    
+    $("#show").change(updateDisplay);
+  });
+  
+});

--- a/source/resource/qx/tool/website/build/index.html
+++ b/source/resource/qx/tool/website/build/index.html
@@ -7,19 +7,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="assets/bootstrap.min.css">
-    <link rel="stylesheet" href="assets/abel.css" >
-    <link rel="icon" href="assets/favicon.png" type="image/png">
+    <link rel="stylesheet" href="/assets/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/abel.css" >
+    <link rel="icon" href="/assets/favicon.png" type="image/png">
 
     <!-- Github buttons -->
-    <script src="assets/buttons.js"></script>
-    <script src="assets/fontawesome-all.js"></script>
+    <script src="/assets/buttons.js"></script>
+    <script src="/assets/fontawesome-all.js"></script>
 
     <title>Qooxdoo Application Server</title>
     <meta name="description" content="">
     <link rel="stylesheet" type="text/css" href="/qooxdoo.css">
-    <script type="text/javascript" src="assets/bluebird.min.js"></script>
-    <script type="text/javascript" src="assets/jquery.js"></script>
+    <script type="text/javascript" src="/assets/bluebird.min.js"></script>
+    <script type="text/javascript" src="/assets/jquery.js"></script>
     <script type="text/javascript" src="/scripts/serve.js"></script>
 </head>
 
@@ -29,7 +29,7 @@
         <div class="container-fluid pt-0">
       <nav class="navbar fixed-top navbar-expand-sm pl-1" id="navigatopnBar">
         <a class="navbar-brand invisible" href="#" style="width: 0" id="navigationLogo">
-          <img src="assets/logo.svg" width="auto" height="30" alt="">
+          <img src="/assets/logo.svg" width="auto" height="30" alt="">
         </a>
         <button class="navbar-toggler navbar-dark" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -74,7 +74,7 @@
          background-color:#002838;
          background-size:8px 8px;
          box-shadow: inset 0 -10px 25px -10px #000000;">
-      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="assets/logo.svg">
+      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="/assets/logo.svg">
       <h3 class="text-white text-center pb-5 d-none d-sm-block" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h3>
       <h5 class="text-white text-center pb-5 d-block d-sm-none" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h5>
     </div>
@@ -193,11 +193,11 @@
         </div>
       </div>
       <div class="container text-center d-none d-sm-block p-4">
-        <img class="img p-4" src="assets/qx-white.svg">
+        <img class="img p-4" src="/assets/qx-white.svg">
         <span class="text-light">&copy; 2005-2018 Qooxdoo Contributors</span>
       </div>
       <div class="container text-center d-block d-sm-none p-4">
-        <img class="img-fluid p-4" src="assets/qx-white.svg">
+        <img class="img-fluid p-4" src="/assets/qx-white.svg">
         <p>&copy; 2005-2017 Qooxdoo Contributors</p>
       </div>
     </div>

--- a/source/resource/qx/tool/website/build/qooxdoo.css
+++ b/source/resource/qx/tool/website/build/qooxdoo.css
@@ -10,6 +10,11 @@
 .carousel-indicators li.active {
   background-color: #AAA; }
 
-#applications li p {
-  font-style: italic;
+#applications li {
   margin-bottom: 0.25em; }
+  #applications li p {
+    font-style: italic;
+    margin-bottom: 0; }
+  #applications li p.tools {
+    margin: 0 0 0 40px;
+    font-size: 11px; }

--- a/source/resource/qx/tool/website/build/qooxdoo.css
+++ b/source/resource/qx/tool/website/build/qooxdoo.css
@@ -16,5 +16,6 @@
     font-style: italic;
     margin-bottom: 0; }
   #applications li p.tools {
+    display: none;
     margin: 0 0 0 40px;
     font-size: 11px; }

--- a/source/resource/qx/tool/website/build/scripts/serve.js
+++ b/source/resource/qx/tool/website/build/scripts/serve.js
@@ -1,23 +1,36 @@
 $(function() {
   
-  function get(uri) {
-    return new Promise(function(resolve, reject) {
-      $.ajax("/serve.api/apps.json", {
-        cache: false,
-        dataType: "json",
-        
-        error: function(jqXHR, textStatus, errorThrown) {
-          reject(textStatus || errorThrown);
-        },
-        
-        success: resolve
-      });
-    });
-  }
+  var query = {};
+  (document.location.search.substring(1)||"").split("&").forEach(function(seg) {
+    var pos = seg.indexOf('=');
+    if (pos > -1) {
+      query[seg.substring(0, pos)] = seg.substring(pos + 1);
+    } else {
+      query[seg] = true;
+    }
+  });
   
-  $.qxcli = {};
+  $.qxcli = {
+    query: query,
+    
+    get: function get(uri) {
+      return new Promise(function(resolve, reject) {
+        $.ajax(uri, {
+          cache: false,
+          dataType: "json",
+          
+          error: function(jqXHR, textStatus, errorThrown) {
+            reject(textStatus || errorThrown);
+          },
+          
+          success: resolve
+        });
+      });
+    }
+  };
+  
   $.qxcli.serve = {
-      apps: get("/serve-api/apps")
+    apps: $.qxcli.get("/serve.api/apps.json")
   };
   
   $.qxcli.pages = {
@@ -38,6 +51,14 @@ $(function() {
               $li.append($a);
               if (appData.description)
                 $li.append($("<p>").text(appData.description))
+              $li.append("<p class='tools'>" +
+                "<a href='diagnostics/dependson.html?targetDir=" + targetData.target.outputDir + 
+                  "&appDir=" + appData.outputPath + 
+                  "&appClass=" + appData.appClass + "'>Depends-On Analysis</a>, " + 
+                "<a href='diagnostics/requiredby.html?targetDir=" + targetData.target.outputDir + 
+                  "&appDir=" + appData.outputPath + 
+                  "&appClass=" + appData.appClass + "'>Required-By Analysis</a>" + 
+                "</p>");
               $ul.append($li);
             });
             $root.append($ul);

--- a/source/resource/qx/tool/website/build/scripts/serve.js
+++ b/source/resource/qx/tool/website/build/scripts/serve.js
@@ -63,6 +63,13 @@ $(function() {
             });
             $root.append($ul);
           });
+          $root.append("<p style='font-size: 10px'><input type='checkbox' id='cbxShowTools'>Show Tools</p>");
+          $("#cbxShowTools").change(function() {
+            if (this.checked)
+              $(".tools").show();
+            else
+              $(".tools").hide();
+          });
         });
     }
   };

--- a/source/resource/qx/tool/website/partials/footer.html
+++ b/source/resource/qx/tool/website/partials/footer.html
@@ -86,11 +86,11 @@
         </div>
       </div>
       <div class="container text-center d-none d-sm-block p-4">
-        <img class="img p-4" src="assets/qx-white.svg">
+        <img class="img p-4" src="/assets/qx-white.svg">
         <span class="text-light">&copy; 2005-2018 Qooxdoo Contributors</span>
       </div>
       <div class="container text-center d-block d-sm-none p-4">
-        <img class="img-fluid p-4" src="assets/qx-white.svg">
+        <img class="img-fluid p-4" src="/assets/qx-white.svg">
         <p>&copy; 2005-2017 Qooxdoo Contributors</p>
       </div>
     </div>

--- a/source/resource/qx/tool/website/partials/head.html
+++ b/source/resource/qx/tool/website/partials/head.html
@@ -4,18 +4,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="assets/bootstrap.min.css">
-    <link rel="stylesheet" href="assets/abel.css" >
-    <link rel="icon" href="assets/favicon.png" type="image/png">
+    <link rel="stylesheet" href="/assets/bootstrap.min.css">
+    <link rel="stylesheet" href="/assets/abel.css" >
+    <link rel="icon" href="/assets/favicon.png" type="image/png">
 
     <!-- Github buttons -->
-    <script src="assets/buttons.js"></script>
-    <script src="assets/fontawesome-all.js"></script>
+    <script src="/assets/buttons.js"></script>
+    <script src="/assets/fontawesome-all.js"></script>
 
     <title>{{= it.title || it.site.title }}</title>
     <meta name="description" content="{{= it.excerpt || it.site.excerpt || "" }}">
     <link rel="stylesheet" type="text/css" href="/qooxdoo.css">
-    <script type="text/javascript" src="assets/bluebird.min.js"></script>
-    <script type="text/javascript" src="assets/jquery.js"></script>
+    <script type="text/javascript" src="/assets/bluebird.min.js"></script>
+    <script type="text/javascript" src="/assets/jquery.js"></script>
     <script type="text/javascript" src="/scripts/serve.js"></script>
 </head>

--- a/source/resource/qx/tool/website/partials/header.html
+++ b/source/resource/qx/tool/website/partials/header.html
@@ -1,7 +1,7 @@
     <div class="container-fluid pt-0">
       <nav class="navbar fixed-top navbar-expand-sm pl-1" id="navigatopnBar">
         <a class="navbar-brand invisible" href="#" style="width: 0" id="navigationLogo">
-          <img src="assets/logo.svg" width="auto" height="30" alt="">
+          <img src="/assets/logo.svg" width="auto" height="30" alt="">
         </a>
         <button class="navbar-toggler navbar-dark" type="button" data-toggle="collapse" data-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -40,7 +40,7 @@
          background-color:#002838;
          background-size:8px 8px;
          box-shadow: inset 0 -10px 25px -10px #000000;">
-      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="assets/logo.svg">
+      <img class="img-fluid mx-auto d-block mt-5 pt-5 pb-3" src="/assets/logo.svg">
       <h3 class="text-white text-center pb-5 d-none d-sm-block" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h3>
       <h5 class="text-white text-center pb-5 d-block d-sm-none" style="font-family: 'Abel', sans-serif;">&raquo;The JS Framework for Coders&laquo;</h5>
     </div>

--- a/source/resource/qx/tool/website/sass/qooxdoo.scss
+++ b/source/resource/qx/tool/website/sass/qooxdoo.scss
@@ -14,7 +14,17 @@
   background-color: #AAA;
 }
 
-#applications li p {
-  font-style: italic;
+#applications li {
   margin-bottom: 0.25em;
+  
+  p {
+    font-style: italic;
+    margin-bottom: 0;
+  }
+  
+  p.tools {
+    margin: 0 0 0 40px;
+    font-size: 11px;
+  }
 }
+

--- a/source/resource/qx/tool/website/sass/qooxdoo.scss
+++ b/source/resource/qx/tool/website/sass/qooxdoo.scss
@@ -23,6 +23,7 @@
   }
   
   p.tools {
+    display: none;
     margin: 0 0 0 40px;
     font-size: 11px;
   }

--- a/source/resource/qx/tool/website/src/diagnostics/dependson.html
+++ b/source/resource/qx/tool/website/src/diagnostics/dependson.html
@@ -1,0 +1,19 @@
+---
+layout: default.dot
+---
+
+<script src="dependson.js"></script>
+<select id="show">
+    <option value="both" selected>runtime and loadtime</option>
+    <option value="runtime">runtime</option>
+    <option value="load">load</option>
+</select>
+
+<style>
+    li {
+        cursor: pointer;
+    }
+</style>
+
+<div id="root">
+</div>

--- a/source/resource/qx/tool/website/src/diagnostics/dependson.js
+++ b/source/resource/qx/tool/website/src/diagnostics/dependson.js
@@ -1,0 +1,65 @@
+$(function() {
+
+  var db;
+
+  function show(name, $list) {
+    var def = db.classInfo[name];
+    if (!def || !def.dependsOn)
+      return;
+    for ( var depName in def.dependsOn) {
+      var isLoad = def.dependsOn[depName].load;
+      var $li = $("<li>").text(depName).attr("data-classname", depName);
+      if (isLoad)
+        $li.addClass("load");
+      else
+        $li.addClass("runtime");
+      $li.click(function(e) {
+        e.stopPropagation();
+        var $this = $(this), className = $this.attr("data-classname"), $ul = $("ul", this);
+        if ($ul.length) {
+          $ul.remove();
+          return;
+        }
+        var $ul = $("<ul>");
+        $this.append($ul);
+        show(className, $ul);
+        updateDisplay();
+      });
+      $list.append($li);
+    }
+  }
+
+  function selectClass(name) {
+    $("#root").append($("<h3>").text(name + " Depends On"));
+    var $root = $("<ul>");
+    $("#root").append($root);
+    show(name, $root);
+  }
+
+  function updateDisplay() {
+    var value = $("#show").val();
+    switch (value) {
+    case "runtime":
+      $(".load").hide();
+      $(".runtime").show();
+      break;
+
+    case "load":
+      $(".load").show();
+      $(".runtime").hide();
+      break;
+
+    default:
+      $(".load").show();
+      $(".runtime").show();
+      break;
+    }
+  }
+
+  $.qxcli.get($.qxcli.query.targetDir + "/db.json").then(function(tmp) {
+    db = tmp;
+    selectClass($.qxcli.query.appClass);
+    $("#show").change(updateDisplay);
+  });
+
+});

--- a/source/resource/qx/tool/website/src/diagnostics/requiredby.html
+++ b/source/resource/qx/tool/website/src/diagnostics/requiredby.html
@@ -1,0 +1,21 @@
+---
+layout: default.dot
+---
+
+<script type="text/javascript" src="requiredby.js"></script>
+
+<select id="show">
+    <option value="both" selected>runtime and loadtime</option>
+    <option value="runtime">runtime</option>
+    <option value="load">load</option>
+</select>
+
+<style>
+    li {
+        cursor: pointer;
+    }
+</style>
+
+<div id="root">
+</div>
+

--- a/source/resource/qx/tool/website/src/diagnostics/requiredby.js
+++ b/source/resource/qx/tool/website/src/diagnostics/requiredby.js
@@ -1,0 +1,78 @@
+$(function() {
+
+  var db;
+
+  function show(name, $list) {
+    var def = db.classInfo[name];
+    if (!def || !def.requiredBy)
+      return;
+    for ( var depName in def.requiredBy) {
+      var $li = $("<li>").text(depName).attr("data-classname", depName);
+      if (def.requiredBy[depName].load)
+        $li.addClass("load");
+      else
+        $li.addClass("runtime");
+      $li.click(function(e) {
+        e.stopPropagation();
+        var $this = $(this), className = $this.attr("data-classname"), $ul = $("ul", this);
+        if ($ul.length) {
+          $ul.remove();
+          return;
+        }
+        var $ul = $("<ul>");
+        $this.append($ul);
+        show(className, $ul);
+        updateDisplay();
+      });
+      $list.append($li);
+    }
+  }
+
+  function selectClass(name) {
+    $("#root").append($("<h3>").text(name + " Required By"));
+    var $root = $("<ul>");
+    $("#root").append($root);
+    show(name, $root);
+  }
+
+  function updateDisplay() {
+    var value = $("#show").val();
+    switch (value) {
+    case "runtime":
+      $(".load").hide();
+      $(".runtime").show();
+      break;
+
+    case "load":
+      $(".load").show();
+      $(".runtime").hide();
+      break;
+
+    default:
+      $(".load").show();
+      $(".runtime").show();
+      break;
+    }
+  }
+
+  $.qxcli.get($.qxcli.query.targetDir + "/db.json").then(function(tmp) {
+    db = tmp;
+    
+    for ( var name in db.classInfo) {
+      var def = db.classInfo[name];
+      if (def.dependsOn)
+        for ( var depName in def.dependsOn) {
+          var depDef = db.classInfo[depName];
+          if (!depDef.requiredBy)
+            depDef.requiredBy = {};
+          depDef.requiredBy[name] = {
+            load: def.dependsOn[depName].load
+          };
+        }
+      selectClass(name);
+    }
+    
+    $("#show").change(updateDisplay);
+  });
+  
+});

--- a/source/resource/qx/tool/website/src/scripts/serve.js
+++ b/source/resource/qx/tool/website/src/scripts/serve.js
@@ -1,23 +1,36 @@
 $(function() {
   
-  function get(uri) {
-    return new Promise(function(resolve, reject) {
-      $.ajax("/serve.api/apps.json", {
-        cache: false,
-        dataType: "json",
-        
-        error: function(jqXHR, textStatus, errorThrown) {
-          reject(textStatus || errorThrown);
-        },
-        
-        success: resolve
-      });
-    });
-  }
+  var query = {};
+  (document.location.search.substring(1)||"").split("&").forEach(function(seg) {
+    var pos = seg.indexOf('=');
+    if (pos > -1) {
+      query[seg.substring(0, pos)] = seg.substring(pos + 1);
+    } else {
+      query[seg] = true;
+    }
+  });
   
-  $.qxcli = {};
+  $.qxcli = {
+    query: query,
+    
+    get: function get(uri) {
+      return new Promise(function(resolve, reject) {
+        $.ajax(uri, {
+          cache: false,
+          dataType: "json",
+          
+          error: function(jqXHR, textStatus, errorThrown) {
+            reject(textStatus || errorThrown);
+          },
+          
+          success: resolve
+        });
+      });
+    }
+  };
+  
   $.qxcli.serve = {
-      apps: get("/serve-api/apps")
+    apps: $.qxcli.get("/serve.api/apps.json")
   };
   
   $.qxcli.pages = {
@@ -38,6 +51,14 @@ $(function() {
               $li.append($a);
               if (appData.description)
                 $li.append($("<p>").text(appData.description))
+              $li.append("<p class='tools'>" +
+                "<a href='diagnostics/dependson.html?targetDir=" + targetData.target.outputDir + 
+                  "&appDir=" + appData.outputPath + 
+                  "&appClass=" + appData.appClass + "'>Depends-On Analysis</a>, " + 
+                "<a href='diagnostics/requiredby.html?targetDir=" + targetData.target.outputDir + 
+                  "&appDir=" + appData.outputPath + 
+                  "&appClass=" + appData.appClass + "'>Required-By Analysis</a>" + 
+                "</p>");
               $ul.append($li);
             });
             $root.append($ul);

--- a/source/resource/qx/tool/website/src/scripts/serve.js
+++ b/source/resource/qx/tool/website/src/scripts/serve.js
@@ -63,6 +63,13 @@ $(function() {
             });
             $root.append($ul);
           });
+          $root.append("<p style='font-size: 10px'><input type='checkbox' id='cbxShowTools'>Show Tools</p>");
+          $("#cbxShowTools").change(function() {
+            if (this.checked)
+              $(".tools").show();
+            else
+              $(".tools").hide();
+          });
         });
     }
   };

--- a/test/bats/dependencies.bats
+++ b/test/bats/dependencies.bats
@@ -18,7 +18,7 @@ teardown() {
   run npx qx package list --short --noheaders --installed --all
   [ "$status" -eq 0 ]
   [ $(echo "$output" | wc -l | tr -d ' ') = "3" ]
-  npx qx compile --feedback=false --warnAsError
+  npx qx compile --feedback=false
 }
 
 @test "Install qxl.test2/qxl.test2A, latest version" {
@@ -26,7 +26,7 @@ teardown() {
   run npx qx package list --short --noheaders --installed --all
   [ "$status" -eq 0 ]
   [ $(echo "$output" | wc -l | tr -d ' ') = "4" ]
-  npx qx compile --feedback=false --warnAsError
+  npx qx compile --feedback=false
 }
 
 @test "Install qxl.test1@release then migrate and upgrade" {
@@ -35,9 +35,9 @@ teardown() {
   cd qx_packages/qooxdoo_qxl_test1_v1_0_2/
   npx qx pkg migrate
   cd ../..
-  npx qx compile --feedback=false --warnAsError
+  npx qx compile --feedback=false
   npx qx pkg upgrade
-  npx qx compile --feedback=false --warnAsError
+  npx qx compile --feedback=false
 }
 
 @test "Install qxl.test1@commit" {
@@ -45,5 +45,5 @@ teardown() {
   run npx qx package list --short --noheaders --installed --all
   [ "$status" -eq 0 ]
   [ $(echo "$output" | wc -l | tr -d ' ') = "3" ]
-  npx qx compile --feedback=false --warnAsError
+  npx qx compile --feedback=false
 }


### PR DESCRIPTION
Various parts of Qooxdoo depend on there being global objects for `window` and `document`, and also that these behave like their browser DOM equivalents to one degree or another.  In many circumstances, a very basic emulation is acceptable but it is possible to incorporate code which requires a much more complete implementation.  

The best (worst) example of this is `qx.bom.Selector` which does lots of feature-detection tests during class initialisation that break badly on NodeJS; this class is depended on by lots of other classes, so even if not used at runtime it causes an issue.  If you want to manipulate DOM-like structures on the server (eg you want to use Qooxdoo's upcoming JSX support ;) ) you may want to use qx.bom.Selector anyway.

This PR adds conditional support for JSDOM to be used *if it is available* - i.e. if you do not add JSDOM via `npm i jsdom` then the previous behaviour is unchanged.

