### PR TITLE
Fixes for JSX and faked DOM in NodeJS

### DIFF
--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -415,6 +415,18 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
 
       // Collect the dependencies on other classes
       var deps = this.getRequiredClasses();
+      if (t.__usesJsx) {
+        let JSX = qx.tool.compiler.ClassFile.JSX_OPTIONS;
+        let classname = JSX.pragma;
+        let pos = classname.lastIndexOf(".");
+        classname = classname.substring(0, pos);
+        if (!deps[classname]) {
+          deps[classname] = {};
+        }
+        if (!deps[JSX.pragmaFrag]) {
+          deps[JSX.pragmaFrag] = {};
+        }
+      }
       for (var name in deps) {
         var dep = deps[name];
         if (!dep.ignore) {
@@ -1144,6 +1156,10 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
 
         EmptyStatement: path => { 
           checkNodeJsDocDirectives(path.node); 
+        },
+        
+        JSXElement(path) {
+          t.__usesJsx = true;
         },
 
         Program: {
@@ -2280,7 +2296,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
      */
     JSX_OPTIONS: {
       "pragma": "qx.html.Jsx.createElement",
-      "pragmaFrag": "qx.html.Jsx.Fragment"
+      "pragmaFrag": "qx.html.JsxFragment"
     },
 
     /**

--- a/source/resource/qx/tool/cli/templates/loader/loader-node.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/loader/loader-node.tmpl.js
@@ -4,33 +4,6 @@
   
   if (typeof window === "undefined") 
     window = this;
-
-  // Node suppresses output to the "real" console when calling console.debug, it's only shown
-  //  in the debugger 
-  console.debug = function() {
-    var args = [].slice.apply(arguments);
-    console.log.apply(this, args);
-  };
-
-  window.document = document = {
-      readyState: "ready",
-      createEvent: function() {
-        return {
-          initCustomEvent: function() {}
-        };
-      },
-      createElement: function () {
-		  return {}
-	  },
-      addListener: function() {},
-      removeListener: function() {},
-      documentElement: {
-        style: {}
-      }
-  };
-
-  if (!this.window) 
-    window = this;
   window.dispatchEvent = function() {};
 
   if (!window.navigator) window.navigator = {};
@@ -39,6 +12,45 @@
   }
   if (!window.navigator.product) window.navigator.product = "";
   if (!window.navigator.cpuClass) window.navigator.cpuClass = "";
+
+  // Node suppresses output to the "real" console when calling console.debug, it's only shown
+  //  in the debugger 
+  console.debug = function() {
+    var args = [].slice.apply(arguments);
+    console.log.apply(this, args);
+  };
+  
+  var JSDOM = null;
+  try {
+    JSDOM = require("jsdom").JSDOM;
+  } catch(ex) {
+    // Nothing
+  }
+  if (JSDOM) {
+    var dom = new JSDOM(`<!DOCTYPE html><html><head></head><body></body></html>`);
+    if (!window)
+      window = dom.window;
+    else {
+      window.document = dom.window.document;
+    }
+  } else {
+    window.document = document = {
+        readyState: "ready",
+        createEvent: function() {
+          return {
+            initCustomEvent: function() {}
+          };
+        },
+        createElement: function () {
+          return {}
+        },
+        addListener: function() {},
+        removeListener: function() {},
+        documentElement: {
+          style: {}
+        }
+    };
+  }
 
   if (!this.qxloadPrefixUrl)
     qxloadPrefixUrl = "";


### PR DESCRIPTION
Various parts of Qooxdoo depend on there being global objects for `window` and `document`, and also that these behave like their browser DOM equivalents to one degree or another. In many circumstances, a very basic emulation is acceptable but it is possible to incorporate code which requires a much more complete implementation.

The best (worst) example of this is qx.bom.Selector which does lots of feature-detection tests during class initialisation that break badly on NodeJS; this class is depended on by lots of other classes, so even if not used at runtime it causes an issue. If you want to manipulate DOM-like structures on the server (eg you want to use Qooxdoo's upcoming JSX support ;) ) you may want to use qx.bom.Selector anyway.

This PR adds conditional support for JSDOM to be used if it is available - i.e. if you do not add JSDOM via `npm i jsdom` then the previous behaviour is unchanged.

This PR also includes a fix for the JSX support to add dependencies for the JSX classes