### PR TITLE
Dependencies and better code elimination

### DIFF
--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -103,7 +103,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
      * @ignore qx.tool.$$resourceDir
      */
     runWebServer: async function() {
-      let makers = this.getMakers().filter(maker => maker.getApplications().some(app => app.isBrowserApp() && app.getStandalone()));
+      let makers = this.getMakers().filter(maker => maker.getApplications().some(app => app.getStandalone()));
       let apps = [];
       let defaultMaker = null;
       let firstMaker = null;
@@ -153,8 +153,9 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
               outputDir: out
             },
             apps: maker.getApplications()
-              .filter(app => app.isBrowserApp() && app.getStandalone())
+              .filter(app => app.getStandalone())
               .map(app => ({
+                isBrowser: app.isBrowserApp(),
                 name: app.getName(),
                 type: app.getType(),
                 title: app.getTitle() || app.getName(),

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -328,9 +328,6 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             filename: t.getSourcePath(),
             sourceMaps: true,
             "presets": [
-              [ require.resolve("@babel/preset-env"), options],
-              [ require.resolve("@babel/preset-typescript") ],
-              [ require.resolve("@babel/preset-react"), qx.tool.compiler.ClassFile.JSX_OPTIONS ],
               [
                 { 
                   plugins: [ myPlugins.CodeElimination ]
@@ -340,7 +337,10 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                 { 
                   plugins: [ myPlugins.Compiler ]
                 }
-              ]
+              ],
+              [ require.resolve("@babel/preset-env"), options],
+              [ require.resolve("@babel/preset-typescript") ],
+              [ require.resolve("@babel/preset-react"), qx.tool.compiler.ClassFile.JSX_OPTIONS ]
             ],
             parserOpts: { sourceType: "script" },
             passPerPreset: true

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -796,9 +796,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             //  use this to remove the unwanted code.
             if (types.isLiteral(node.test)) {
               if (node.test.value) {
-                path.replaceWithMultiple(node.consequent.body);
+                path.replaceWith(node.consequent);
               } else if (node.alternate) {
-                path.replaceWithMultiple(node.alternate.body);
+                path.replaceWith(node.alternate);
               } else {
                 path.remove();
               }
@@ -914,7 +914,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
         } else if (node.type == "NewExpression" || node.type == "BinaryExpression") {
           result = "[[ " + node.type + " ]]";
         } else {
-          t.warn("Cannot interpret AST " + node.type + " at " + t.__className + " [" + node.loc.start.line + "," + node.loc.start.column + "]");
+          t.warn("Cannot interpret AST " + node.type + " at " + t.__className + 
+              (node.loc ? " [" + node.loc.start.line + "," + node.loc.start.column + "]" : ""));
           result = null;
         }
         return result;
@@ -1182,8 +1183,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
               var tmp = types.callExpression(fn, [
                 path.node,
                 types.stringLiteral(t.__className.replace(/\./g, "/") + ".js"),
-                types.numericLiteral(path.node.loc.start.line),
-                types.numericLiteral(path.node.loc.start.column)
+                types.numericLiteral(path.node.loc ? path.node.loc.start.line : 0),
+                types.numericLiteral(path.node.loc ? path.node.loc.start.column : 0)
               ]);
               path.replaceWith(tmp);
               path.skip();
@@ -1343,7 +1344,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             }
 
             function addTranslation(entry) {
-              let lineNo = path.node.loc.start.line;
+              let lineNo = path.node.loc ? path.node.loc.start.line : 0;
               let cur = t.__translations[entry.msgid];
               if (cur) {
                 if (!qx.lang.Type.isArray(cur.lineNo)) {
@@ -2072,6 +2073,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
      *  where {"ignore"|"require"|"use"|null} where it's mentioned
      *  load {Boolean?} whether it is a load-time dependency or not
      *  defer {Boolean?} whether the dependency is in defer or not
+     *  location {Map?} location of the token that caused the reference
      * @return {Map?} info about the symbol type of the named class, @see {Analyser.getSymbolType}
      */
     _requireClass: function(name, opts) {

--- a/source/class/qx/tool/compiler/Console.js
+++ b/source/class/qx/tool/compiler/Console.js
@@ -199,8 +199,10 @@ qx.Class.define("qx.tool.compiler.Console", {
 
       "qx.tool.compiler.target.missingBootJs": "There is no reference to boot.js script in the index.html copied from %1 (see https://git.io/fh7NI)",
       /* eslint-disable no-template-curly-in-string */
-      "qx.tool.compiler.target.missingPreBootJs": "There is no reference to ${preBootJs} in the index.html copied from %1 (see https://git.io/fh7NI)"
+      "qx.tool.compiler.target.missingPreBootJs": "There is no reference to ${preBootJs} in the index.html copied from %1 (see https://git.io/fh7NI)",
       /* eslint-enable no-template-curly-in-string */
+      
+      "qx.tool.compiler.maker.appNotHeadless": "Compiling application '%1' but the target supports non-headless output, you may find unwanted dependencies are loaded during startup"
     }, "warning");
   },
 

--- a/source/class/qx/tool/compiler/app/Application.js
+++ b/source/class/qx/tool/compiler/app/Application.js
@@ -802,10 +802,10 @@ qx.Class.define("qx.tool.compiler.app.Application", {
      */
     getCalculatedEnvironment() {
       return qx.tool.utils.Values.merge(
-          {
-            "qx.headless": this.getType() != "browser"
-          },
-          this.getEnvironment());
+        {
+          "qx.headless": this.getType() != "browser"
+        },
+        this.getEnvironment());
     },
     
     /**

--- a/source/class/qx/tool/compiler/app/Application.js
+++ b/source/class/qx/tool/compiler/app/Application.js
@@ -793,7 +793,21 @@ qx.Class.define("qx.tool.compiler.app.Application", {
     getParts: function() {
       return this.__parts || [];
     },
-
+    
+    /**
+     * Returns a dynamically calculated version of the application environment, which
+     * is defaults or dynamic values plus the `environment` property
+     * 
+     * @return {Map} The environment settings
+     */
+    getCalculatedEnvironment() {
+      return qx.tool.utils.Values.merge(
+          {
+            "qx.headless": this.getType() != "browser"
+          },
+          this.getEnvironment());
+    },
+    
     /**
      * Expands a list of class names including wildcards (eg "qx.ui.*") into an
      * exhaustive list without wildcards

--- a/source/class/qx/tool/compiler/makers/AppMaker.js
+++ b/source/class/qx/tool/compiler/makers/AppMaker.js
@@ -87,30 +87,46 @@ qx.Class.define("qx.tool.compiler.makers.AppMaker", {
         this.getEnvironment(),
         this.getTarget().getEnvironment());
 
-      // Application env settings must be removed from the global and bumped into the application's
-      //  environment settings (to avoid code elimination)
-      const allAppEnv = {};
+      let appEnvironments = {};
       this.getApplications().forEach(app => {
-        let appEnv = app.getEnvironment();
-        if (appEnv) {
-          for (let key in appEnv) {
-            allAppEnv[key] = true;
-          }
-        }
+        appEnvironments[app.toHashCode()] = qx.tool.utils.Values.merge({}, compileEnv, app.getCalculatedEnvironment());
       });
+      
+      // Analyze the list of environment variables, detect which are shared between all apps
+      let allAppEnv = {};
       this.getApplications().forEach(app => {
-        let appEnv = app.getEnvironment();
-        if (appEnv) {
-          for (let key in allAppEnv) {
-            if (compileEnv[key] !== undefined && appEnv[key] === undefined) {
-              appEnv[key] = compileEnv[key];
-            }
+        let env = appEnvironments[app.toHashCode()];
+        Object.keys(env).forEach(key => {
+          if (!allAppEnv[key]) {
+            allAppEnv[key] = {
+                value: env[key],
+                same: true
+            };
+          } else if (allAppEnv[key].value !== env[key]) {
+            allAppEnv[key].same = false;
           }
-        }
+        });
       });
-      for (let key in allAppEnv) {
-        delete compileEnv[key];
-      }
+      
+      // If an env setting is the same for all apps, move it to the target for code elimination; similarly,
+      //  if it varies between apps, then remove it from the target and make each app specify it individually
+      this.getApplications().forEach(app => {
+        let env = appEnvironments[app.toHashCode()];
+        Object.keys(allAppEnv).forEach(key => {
+          if (allAppEnv[key].same)
+            delete env[key];
+          else if (env[key] === undefined)
+            env[key] = compileEnv[key];
+        });
+      });
+      
+      // Cleanup to remove env that have been moved to the app 
+      Object.keys(allAppEnv).forEach(key => {
+        if (allAppEnv[key].same)
+          compileEnv[key] = allAppEnv[key].value;
+        else
+          delete compileEnv[key];
+      });
 
       return this.checkCompileVersion()
         .then(() => this.writeCompileVersion())
@@ -165,7 +181,10 @@ qx.Class.define("qx.tool.compiler.makers.AppMaker", {
 
           let db = analyser.getDatabase();
           var promises = appsThisTime.map(application => {
-            var appEnv = qx.tool.utils.Values.merge({}, compileEnv, application.getEnvironment());
+            if (application.getType() != "browser" && !compileEnv["qx.headless"]) {
+              qx.tool.compiler.Console.print("qx.tool.compiler.maker.appNotHeadless", application.getName());
+            }
+            var appEnv = qx.tool.utils.Values.merge({}, compileEnv, appEnvironments[application.toHashCode()]);
             application.calcDependencies();
             if (application.getFatalCompileErrors()) {
               qx.tool.compiler.Console.print("qx.tool.compiler.maker.appFatalError", application.getName());

--- a/source/class/qx/tool/compiler/makers/AppMaker.js
+++ b/source/class/qx/tool/compiler/makers/AppMaker.js
@@ -99,8 +99,8 @@ qx.Class.define("qx.tool.compiler.makers.AppMaker", {
         Object.keys(env).forEach(key => {
           if (!allAppEnv[key]) {
             allAppEnv[key] = {
-                value: env[key],
-                same: true
+              value: env[key],
+              same: true
             };
           } else if (allAppEnv[key].value !== env[key]) {
             allAppEnv[key].same = false;
@@ -113,19 +113,21 @@ qx.Class.define("qx.tool.compiler.makers.AppMaker", {
       this.getApplications().forEach(app => {
         let env = appEnvironments[app.toHashCode()];
         Object.keys(allAppEnv).forEach(key => {
-          if (allAppEnv[key].same)
+          if (allAppEnv[key].same) {
             delete env[key];
-          else if (env[key] === undefined)
+          } else if (env[key] === undefined) {
             env[key] = compileEnv[key];
+          }
         });
       });
       
       // Cleanup to remove env that have been moved to the app 
       Object.keys(allAppEnv).forEach(key => {
-        if (allAppEnv[key].same)
+        if (allAppEnv[key].same) {
           compileEnv[key] = allAppEnv[key].value;
-        else
+        } else {
           delete compileEnv[key];
+        }
       });
 
       return this.checkCompileVersion()

--- a/source/class/qx/tool/compiler/resources/ScssFile.js
+++ b/source/class/qx/tool/compiler/resources/ScssFile.js
@@ -176,10 +176,6 @@ qx.Class.define("qx.tool.compiler.resources.ScssFile", {
     },
     
     async loadSource(filename, library) {
-      function esc(str) {
-        return str.replace(/([\[\]\\])/g, "\\$1");
-      }
-      
       filename = path.relative(process.cwd(), path.resolve(this.isThemeFile() ? library.getThemeFilename(filename) : library.getResourceFilename(filename)));
       let absFilename = filename;
       if (path.extname(absFilename) == "") {

--- a/source/class/qx/tool/compiler/resources/ScssFile.js
+++ b/source/class/qx/tool/compiler/resources/ScssFile.js
@@ -77,12 +77,6 @@ qx.Class.define("qx.tool.compiler.resources.ScssFile", {
       this.__absLocations = {};
       
       let inputFileData = await this.loadSource(this.__filename, this.__library);
-      inputFileData = 
-        `
-        @function qooxdooUrl($url) { 
-          @return __qooxdooUrlImpl($__library, $__filename, $url); 
-        }
-        ` + inputFileData;
       
       await new qx.Promise((resolve, reject) => {
         nodeSass.render({
@@ -111,8 +105,8 @@ qx.Class.define("qx.tool.compiler.resources.ScssFile", {
           },
           
           functions: {
-            "__qooxdooUrlImpl($library, $filename, $url)": ($library, $filename, $url, done) =>
-              this.__qooxdooUrlImpl($library, $filename, $url, done)
+            "qooxdooUrl($filename, $url)": ($filename, $url, done) =>
+              this.__qooxdooUrlImpl($filename, $url, done)
           }
         }, 
         (error, result) => {
@@ -133,7 +127,7 @@ qx.Class.define("qx.tool.compiler.resources.ScssFile", {
     },
     
     _analyseFilename(url, currentFilename) {
-      var m = url.match(/^([a-z0-9_]+):(\/?[^\/].*)/);
+      var m = url.match(/^([a-z0-9_.]+):(\/?[^\/].*)/);
       if (m) {
         return {
           namespace: m[1],
@@ -228,27 +222,33 @@ qx.Class.define("qx.tool.compiler.resources.ScssFile", {
         return "@import \"" + path.relative(process.cwd(), newLibrary.getResourceFilename(pathInfo.filename)) + "\"";
       });
       
-      contents = contents.replace(/\burl\s*\(\s*([^\)]+)*\)/ig, (match, p1) => {
-        let c = p1[0];
+      contents = contents.replace(/\burl\s*\(\s*([^\)]+)*\)/ig, (match, url) => {
+        let c = url[0];
         if (c === "\'" || c === "\"") {
-          p1 = p1.substring(1);
+          url = url.substring(1);
         }
-        c = p1[p1.length - 1];
+        c = url[url.length - 1];
         if (c === "\'" || c === "\"") {
-          p1 = p1.substring(0, p1.length - 1);
+          url = url.substring(0, url.length - 1);
         }
-        return "qooxdooUrl(\"" + p1 + "\")";
+        //return `qooxdooUrl("${filename}", "${url}")`;
+        let pathInfo = this._analyseFilename(url, filename);
+        
+        if (pathInfo) {
+          if (pathInfo.externalUrl) {
+            return `url("${pathInfo.externalUrl}")`;
+          }
+          
+          if (pathInfo.namespace) {
+            let targetFile = path.relative(process.cwd(), path.join(this.__target.getOutputDir(), "resource", pathInfo.filename));
+            let relative = path.relative(this.__outputDir, targetFile);
+            return `url("${relative}")`;
+          }
+        }
+        
+        return `url("${url}")`;
       });
 
-      contents = [
-        "$__dirname:  \"" + esc(path.dirname(filename)) + "\";",
-        "$__library:  \"" + esc(library.getNamespace()) + "\";",
-        "$__filename: \"" + esc(filename)+"\";",
-        contents,
-        "$__dirname:  \"__null__\";",
-        "$__library:  \"__null__\";",
-        "$__filename: \"__null__\";"
-      ].join("\n");
       this.__sourceFiles[absFilename] = contents;
       this.__importAs[filename] = absFilename;
       
@@ -260,21 +260,24 @@ qx.Class.define("qx.tool.compiler.resources.ScssFile", {
       return Object.keys(this.__sourceFiles);
     },
     
-    __qooxdooUrlImpl($libraryNamespace, $filename, $url, done) {
+    __qooxdooUrlImpl($filename, $url, done) {
       let currentFilename = $filename.getValue();
       let url = $url.getValue();
       
       let pathInfo = this._analyseFilename(url, currentFilename);
       
-      if (pathInfo.externalUrl) {
-        return nodeSass.types.String("url(" + pathInfo.externalUrl + ")");
+      if (pathInfo) {
+        if (pathInfo.externalUrl) {
+          return nodeSass.types.String("url(" + pathInfo.externalUrl + ")");
+        }
+        
+        if (pathInfo.namespace) {
+          let targetFile = path.relative(process.cwd(), path.join(this.__target.getOutputDir(), "resource", pathInfo.filename));
+          let relative = path.relative(this.__outputDir, targetFile);
+          return nodeSass.types.String("url(" + relative + ")");
+        }
       }
       
-      if (pathInfo.namespace) {
-        let targetFile = path.relative(process.cwd(), path.join(this.__target.getOutputDir(), "resource", pathInfo.filename));
-        let relative = path.relative(this.__outputDir, targetFile);
-        return nodeSass.types.String("url(" + relative + ")");
-      }
       return nodeSass.types.String("url(" + url + ")");
     }    
   }

--- a/source/class/qx/tool/compiler/targets/Target.js
+++ b/source/class/qx/tool/compiler/targets/Target.js
@@ -299,7 +299,7 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
       var library = compileInfo.library = analyser.getLibraryFromClassname(appClassname);
       if (!library) {
         qx.tool.compiler.Console.print("qx.tool.compiler.target.missingAppLibrary", appClassname);
-        return qx.Promise.resolve();
+        return;
       }
       const requiredLibs = application.getRequiredLibraries();
       var namespace = compileInfo.namespace = library.getNamespace();
@@ -454,8 +454,8 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
             if (code) {
               configdata.preBootCode.push(code);
             }
-          }catch(ex) {
-            qx.tool.compiler.Console.print("qx.tool.compiler.webfonts.error", font.toString(), err.toString());
+          } catch (ex) {
+            qx.tool.compiler.Console.print("qx.tool.compiler.webfonts.error", font.toString(), ex.toString());
           }
           promises.push(p);
         };
@@ -695,12 +695,12 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
       var appRootDir = this.getApplicationRoot(application);
       
       var APP_SUMMARY = {
-          appClass: application.getClassName(),
-          libraries: Object.keys(compileInfo.configdata.libraries).filter(ns => ns != "__out__"),
-          parts: [],
-          resources: compileInfo.configdata.resources,
-          locales: compileInfo.configdata.locales,
-          environment: compileInfo.configdata.environment
+        appClass: application.getClassName(),
+        libraries: Object.keys(compileInfo.configdata.libraries).filter(ns => ns != "__out__"),
+        parts: [],
+        resources: compileInfo.configdata.resources,
+        locales: compileInfo.configdata.locales,
+        environment: compileInfo.configdata.environment
       };
       compileInfo.parts.forEach(part => {
         APP_SUMMARY.parts.push({
@@ -782,8 +782,8 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
       }
 
       await fs.writeFileAsync(appRootDir + "/" + t.getScriptPrefix() + "app-summary.json",
-          JSON.stringify(APP_SUMMARY, null, 2) + "\n",
-          { encoding: "utf8" });
+        JSON.stringify(APP_SUMMARY, null, 2) + "\n",
+        { encoding: "utf8" });
       
       await fs.writeFileAsync(appRootDir + "/" + t.getScriptPrefix() + "resources.js",
         "qx.$$packageData['0'] = " + JSON.stringify(compileInfo.pkgdata, null, 2) + ";\n",

--- a/source/resource/qx/tool/website/build/diagnostics/dependson.js
+++ b/source/resource/qx/tool/website/build/diagnostics/dependson.js
@@ -1,12 +1,16 @@
 $(function() {
 
   var db;
+  var appDb;
+  var CLASSES = {};
 
   function show(name, $list) {
     var def = db.classInfo[name];
     if (!def || !def.dependsOn)
       return;
     for ( var depName in def.dependsOn) {
+      if (!CLASSES[depName])
+        continue;
       var isLoad = def.dependsOn[depName].load;
       var $li = $("<li>").text(depName).attr("data-classname", depName);
       if (isLoad)
@@ -56,10 +60,18 @@ $(function() {
     }
   }
 
-  $.qxcli.get($.qxcli.query.targetDir + "/db.json").then(function(tmp) {
-    db = tmp;
-    selectClass($.qxcli.query.appClass);
-    $("#show").change(updateDisplay);
-  });
-
+  var query = $.qxcli.query;
+  $.qxcli.get(query.targetDir + "/db.json")
+    .then(function(tmp) {
+      db = tmp;
+      return $.qxcli.get(query.targetDir + "/" + query.appDir + "/app-summary.json");
+    })
+    .then(function(tmp) {
+      appDb = tmp;
+      appDb.parts.forEach(function(part) {
+        part.classes.forEach(classname => CLASSES[classname] = true);
+      });
+      selectClass($.qxcli.query.appClass);
+      $("#show").change(updateDisplay);
+    });
 });

--- a/source/resource/qx/tool/website/build/scripts/serve.js
+++ b/source/resource/qx/tool/website/build/scripts/serve.js
@@ -43,12 +43,23 @@ $(function() {
           data.forEach(targetData => {
             $root.append($("<h2>").text((targetData.target.type == "build" ? "Build" : "Source") + " Target in " + targetData.target.outputDir));
             var $ul = $("<ul>");
+            targetData.apps.sort(function(l, r) {
+              l = l.title || l.name;
+              r = r.title || r.name;
+              return l < r ? -1 : l > r ? 1 : 0;
+            });
             targetData.apps.forEach(function(appData) {
               var $li = $("<li>");
-              var $a = $("<a>");
-              $a.text(appData.title || appData.name);
-              $a.attr("href", targetData.target.outputDir + appData.outputPath + "/index.html");
-              $li.append($a);
+              if (appData.isBrowser) {
+                var $a = $("<a>");
+                $a.text(appData.title || appData.name);
+                $a.attr("href", targetData.target.outputDir + appData.outputPath + "/index.html");
+                $li.append($a);
+              } else {
+                var $p = $("<p>");
+                $p.text(appData.title || appData.name);
+                $li.append($p);
+              }
               if (appData.description)
                 $li.append($("<p>").text(appData.description))
               $li.append("<p class='tools'>" +

--- a/source/resource/qx/tool/website/src/diagnostics/dependson.js
+++ b/source/resource/qx/tool/website/src/diagnostics/dependson.js
@@ -1,12 +1,16 @@
 $(function() {
 
   var db;
+  var appDb;
+  var CLASSES = {};
 
   function show(name, $list) {
     var def = db.classInfo[name];
     if (!def || !def.dependsOn)
       return;
     for ( var depName in def.dependsOn) {
+      if (!CLASSES[depName])
+        continue;
       var isLoad = def.dependsOn[depName].load;
       var $li = $("<li>").text(depName).attr("data-classname", depName);
       if (isLoad)
@@ -56,10 +60,18 @@ $(function() {
     }
   }
 
-  $.qxcli.get($.qxcli.query.targetDir + "/db.json").then(function(tmp) {
-    db = tmp;
-    selectClass($.qxcli.query.appClass);
-    $("#show").change(updateDisplay);
-  });
-
+  var query = $.qxcli.query;
+  $.qxcli.get(query.targetDir + "/db.json")
+    .then(function(tmp) {
+      db = tmp;
+      return $.qxcli.get(query.targetDir + "/" + query.appDir + "/app-summary.json");
+    })
+    .then(function(tmp) {
+      appDb = tmp;
+      appDb.parts.forEach(function(part) {
+        part.classes.forEach(classname => CLASSES[classname] = true);
+      });
+      selectClass($.qxcli.query.appClass);
+      $("#show").change(updateDisplay);
+    });
 });

--- a/source/resource/qx/tool/website/src/scripts/serve.js
+++ b/source/resource/qx/tool/website/src/scripts/serve.js
@@ -43,12 +43,23 @@ $(function() {
           data.forEach(targetData => {
             $root.append($("<h2>").text((targetData.target.type == "build" ? "Build" : "Source") + " Target in " + targetData.target.outputDir));
             var $ul = $("<ul>");
+            targetData.apps.sort(function(l, r) {
+              l = l.title || l.name;
+              r = r.title || r.name;
+              return l < r ? -1 : l > r ? 1 : 0;
+            });
             targetData.apps.forEach(function(appData) {
               var $li = $("<li>");
-              var $a = $("<a>");
-              $a.text(appData.title || appData.name);
-              $a.attr("href", targetData.target.outputDir + appData.outputPath + "/index.html");
-              $li.append($a);
+              if (appData.isBrowser) {
+                var $a = $("<a>");
+                $a.text(appData.title || appData.name);
+                $a.attr("href", targetData.target.outputDir + appData.outputPath + "/index.html");
+                $li.append($a);
+              } else {
+                var $p = $("<p>");
+                $p.text(appData.title || appData.name);
+                $li.append($p);
+              }
               if (appData.description)
                 $li.append($("<p>").text(appData.description))
               $li.append("<p class='tools'>" +

--- a/test/test-deps.js
+++ b/test/test-deps.js
@@ -50,13 +50,28 @@ async function createMaker() {
       envVar2: "222",
       envVar3: "333",
       "test.appValue": true,
-      "qx.promise": true,
+      "qx.promise": false,
       "test.overridden1": true,
       "test.overridden2": false,
       "test.overridden5": "application"
     },
     templatePath: "../source/resource/qx/tool/cli/templates",
     writeIndexHtmlToRoot: true
+  }));
+  
+  maker.addApplication(new qx.tool.compiler.app.Application("testapp.Application").set({
+    theme: "qx.theme.Indigo",
+    name: "apptwo",
+    environment: {
+      envVar2: "222",
+      envVar3: "apptwo-envVar3",
+      "test.appValue": true,
+      "qx.promise": true,
+      "test.overridden1": true,
+      "test.overridden2": false,
+      "test.overridden5": "application"
+    },
+    templatePath: "../source/resource/qx/tool/cli/templates"
   }));
   
   let analyser = maker.getAnalyser();
@@ -226,14 +241,14 @@ test("Checks dependencies and environment settings", assert => {
       .then(src => {
         assert.ok(!src.match(/ELIMINATION_FAILED/), "Code elimination");
         assert.ok(src.match(/TEST_OVERRIDDEN_1/), "Overridden environment vars #1");
-        assert.ok(src.match(/TEST_OVERRIDDEN_2/), "Overridden environment vars #2");
+        assert.ok(!src.match(/TEST_OVERRIDDEN_2/), "Overridden environment vars #2");
         assert.ok(src.match(/var envVar1 = "ONE"/), "environment setting for envVar1");
-        assert.ok(src.match(/var envVar2 = qx.core.Environment.get\("envVar2"\)/), "environment setting for envVar2");
+        assert.ok(src.match(/var envVar2 = "222"/), "environment setting for envVar2");
         assert.ok(src.match(/var envVar3 = qx.core.Environment.get\("envVar3"\)/), "environment setting for envVar3");
         assert.ok(src.match(/var envVar4 = "four"/), "environment setting for envVar4");
         assert.ok(src.match(/var envTestOverriden3 = "global"/), "environment setting for envTestOverriden3");
         assert.ok(src.match(/var envTestOverriden4 = "target"/), "environment setting for envTestOverriden4");
-        assert.ok(src.match(/var envTestOverriden5 = qx.core.Environment.get\("test.overridden5"\)/), "environment setting for envTestOverriden5");
+        assert.ok(src.match(/var envTestOverriden5 = "application"/), "environment setting for envTestOverriden5");
         assert.ok(src.match(/var envVarSelect3 = 0/), "environment setting for envVarSelect3");
         assert.ok(src.match(/var envVarDefault1 = "some"/), "environment setting for envVarDefault1");
         assert.ok(src.match(/var envVarDefault2 = qx.core.Environment.get("test.noValue") || "default2"/), "environment setting for envVarDefault2");


### PR DESCRIPTION
This PR resolves some issues with dependencies, to remove unnecessarily loading classes which are not needed and to avoid creating dependencies that are not wanted.

The ClassFile fixes a bug where dependencies were not taking account of code elimination, ie if a `if (qx.core.Environment.get(...)) {}` is false and causes code to be removed, then any class references within the removed code should not be counted as a dependency and therefore should not be loaded by the boot loader.

A lot of the event handling code in Qooxdoo (eg gestures and pointer event handlers) do work during class initialisation (eg `defer`) that will fail with an exception during app startup unless the app is running in a browser.  This is an issue because some of the utility classes which a nodejs/rhino could legitimately use have dependencies to those browser-only classes, so even if you do not use the utility classes to do any actual browser-only code, your application will still break on nodejs/rhino.

There is a new environment test called `qx.headless` which can be used to determine whether the target is browser or non-browser - this allows Qooxdoo to eliminate code from non-browser targets which cause a reference to browser-only classes that must not be loaded.  

`qx.headless` is defined by the compiler depending on the target type (this is backwards compatible with the generator, except that the user would be required to manually define the `qx.headless` in their config.json if they wanted to use it).  There is a PR coming to Qooxdoo "real soon now" which takes advantage of this setting.

If you have a target which is supporting both headless (nodejs/rhino) and browser applications, then the compile cannot optimise out those dependencies - depending on the code in your nodejs application this may or may not be an issue, but the compiler outputs a warning just in case.
