### PR TITLE
Add support for setting application variables

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5798,6 +5798,11 @@
         }
       }
     },
+    "object-hash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.1.tgz",
+      "integrity": "sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA=="
+    },
     "object-inspect": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "mkdirp": "^0.5.1",
     "node-fetch": "^1.7.3",
     "node-sass": "^4.12.0",
+    "object-hash": "^2.0.1",
     "ps-tree": "^1.2.0",
     "replace-in-file": "^4.1.2",
     "rimraf": "^2.6.2",

--- a/source/class/qx/tool/cli/Cli.js
+++ b/source/class/qx/tool/cli/Cli.js
@@ -45,12 +45,21 @@ qx.Class.define("qx.tool.cli.Cli", {
 
       let yargs = require("yargs").locale("en");
       yargs.option("set", {
-        describe: "sets an environment value",
+        describe: "sets an environment value for the compiler",
         nargs: 1,
         requiresArg: true,
         type: "string",
         array: true
       });
+
+      yargs.option("set-env", {
+        describe: "sets an environment value for the compilation result",
+        nargs: 1,
+        requiresArg: true,
+        type: "string",
+        array: true
+      });
+
       qx.tool.cli.Cli.addYargsCommands(yargs,
         [
           "Add",

--- a/source/class/qx/tool/cli/Cli.js
+++ b/source/class/qx/tool/cli/Cli.js
@@ -44,6 +44,7 @@ qx.Class.define("qx.tool.cli.Cli", {
       Type qx <command> --help for options and subcommands.`;
 
       let yargs = require("yargs").locale("en");
+
       yargs.option("set", {
         describe: "sets an environment value for the compiler",
         nargs: 1,
@@ -53,11 +54,22 @@ qx.Class.define("qx.tool.cli.Cli", {
       });
 
       yargs.option("set-env", {
-        describe: "sets an environment value for the compilation result",
+        describe: "sets an environment value for the application",
         nargs: 1,
         requiresArg: true,
         type: "string",
         array: true
+      })
+      .check((argv) => {
+        // validate that "set-env" is not set or if it is
+        // set it's items are strings in the form of key=value
+        const regexp = /^[^=\s]+=.+$/;
+        const setEnv = argv["set-env"];
+
+        if (!(setEnv === undefined || !setEnv.some((item) => !regexp.test(item)))) {
+          throw (new Error("Argument check failed: --set-env must be a key=value pair."));
+        }
+        return true;
       });
 
       qx.tool.cli.Cli.addYargsCommands(yargs,

--- a/source/class/qx/tool/cli/Cli.js
+++ b/source/class/qx/tool/cli/Cli.js
@@ -60,17 +60,17 @@ qx.Class.define("qx.tool.cli.Cli", {
         type: "string",
         array: true
       })
-      .check((argv) => {
-        // validate that "set-env" is not set or if it is
-        // set it's items are strings in the form of key=value
-        const regexp = /^[^=\s]+=.+$/;
-        const setEnv = argv["set-env"];
+        .check(argv => {
+          // validate that "set-env" is not set or if it is
+          // set it's items are strings in the form of key=value
+          const regexp = /^[^=\s]+=.+$/;
+          const setEnv = argv["set-env"];
 
-        if (!(setEnv === undefined || !setEnv.some((item) => !regexp.test(item)))) {
-          throw (new Error("Argument check failed: --set-env must be a key=value pair."));
-        }
-        return true;
-      });
+          if (!(setEnv === undefined || !setEnv.some(item => !regexp.test(item)))) {
+            throw (new Error("Argument check failed: --set-env must be a key=value pair."));
+          }
+          return true;
+        });
 
       qx.tool.cli.Cli.addYargsCommands(yargs,
         [

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -115,7 +115,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       },
       "erase": {
         alias: "e",
-        describe: "Enabled automatic deletion of the output directory when compiler version changes",
+        describe: "Enabled automatic deletion of the output directory when compiler version or environment variables change",
         type: "boolean",
         default: true
       },

--- a/source/class/qx/tool/cli/commands/MConfig.js
+++ b/source/class/qx/tool/cli/commands/MConfig.js
@@ -209,6 +209,7 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
         config.environment = {};
       }
 
+      qx.lang.Object.mergeWith(config.environment, parsedArgs.environment, true);
       if (!config.libraries) {
         config.libraries = [ "." ];
       }
@@ -251,6 +252,20 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
       if (argv.locale && argv.locale.length) {
         result.locales = argv.locale;
       }
+
+      if (argv["set-env"]) {
+        argv["set-env"].forEach(function(kv) {
+          var m = kv.match(/^([^=\s]+)(=(.+))?$/);
+          if (m) {
+            var key = m[1];
+            var value = m[3];
+            result.environment[key] = value;
+          } else {
+            throw new qx.tool.utils.Utils.UserError(`Failed to parse environment setting commandline option '--set-env ${kv}'`);
+          }
+        });
+      }
+
       return result;
     },
 

--- a/source/class/qx/tool/cli/commands/MConfig.js
+++ b/source/class/qx/tool/cli/commands/MConfig.js
@@ -256,13 +256,9 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
       if (argv["set-env"]) {
         argv["set-env"].forEach(function(kv) {
           var m = kv.match(/^([^=\s]+)(=(.+))?$/);
-          if (m) {
-            var key = m[1];
-            var value = m[3];
-            result.environment[key] = value;
-          } else {
-            throw new qx.tool.utils.Utils.UserError(`Failed to parse environment setting commandline option '--set-env ${kv}'`);
-          }
+          var key = m[1];
+          var value = m[3];
+          result.environment[key] = value;
         });
       }
 

--- a/source/class/qx/tool/compiler/Analyser.js
+++ b/source/class/qx/tool/compiler/Analyser.js
@@ -29,6 +29,7 @@ var async = require("async");
 require("@qooxdoo/framework");
 var util = require("./util");
 var jsonlint = require("jsonlint");
+var hash = require('object-hash');
 
 require("./ClassFile");
 require("./app/Library");
@@ -1048,6 +1049,25 @@ qx.Class.define("qx.tool.compiler.Analyser", {
           })
           .then(() => translation.write());
       }));
+    },
+
+    /**
+     * Generates a hash from the environmentObject and updates the existing hash if it differs from the generated.
+     *
+     * @param environmentObject {Object} The object containing environment variables
+     * @return {Boolean} whether the hash was updated
+     */
+    refreshEnvironmentHash: function(environmentObject) {
+      var db = this.getDatabase();
+      var environmentHash = hash(environmentObject);
+      var updated = false;
+
+      if (db && (db.environmentHash !== environmentHash)) {
+        db.environmentHash = environmentHash;
+        updated = true;
+      }
+
+      return updated;
     },
 
     /**

--- a/source/class/qx/tool/compiler/Analyser.js
+++ b/source/class/qx/tool/compiler/Analyser.js
@@ -29,7 +29,7 @@ var async = require("async");
 require("@qooxdoo/framework");
 var util = require("./util");
 var jsonlint = require("jsonlint");
-var hash = require('object-hash');
+var hash = require("object-hash");
 
 require("./ClassFile");
 require("./app/Library");

--- a/source/class/qx/tool/compiler/makers/AppMaker.js
+++ b/source/class/qx/tool/compiler/makers/AppMaker.js
@@ -23,6 +23,7 @@
 require("@qooxdoo/framework");
 require("./AbstractAppMaker");
 var util = require("../util");
+const mkParentPath = util.promisify(util.mkParentPath);
 
 /**
  * Application maker; supports multiple applications to compile against a single
@@ -117,21 +118,20 @@ qx.Class.define("qx.tool.compiler.makers.AppMaker", {
         .then(() => {
           analyser.setEnvironment(compileEnv);
 
-          if (analyser.environmentChanged()) {
+          if (!this.isNoErase() && analyser.isContextChanged()) {
             return this.eraseOutputDir()
+              .then(() => mkParentPath(this.getOutputDir()))
               .then(() => analyser.resetDatabase());
           }
           return Promise.resolve();
         })
-        .then(() => this.checkCompileVersion())
-        .then(() => this.writeCompileVersion())
+        .then(() => util.promisifyThis(analyser.initialScan, analyser))
+        .then(() => analyser.updateEnvironmentData())
         .then(() => {
           this.getTarget().setAnalyser(analyser);
           this.__applications.forEach(app => app.setAnalyser(analyser));
           return this.getTarget().open();
         })
-        .then(() => util.promisifyThis(analyser.initialScan, analyser))
-        .then(() => analyser.saveDatabase())
         .then(() => {
           if (this.isOutputTypescript()) {
             analyser.getLibraries().forEach(library => {

--- a/source/class/qx/tool/compiler/makers/Maker.js
+++ b/source/class/qx/tool/compiler/makers/Maker.js
@@ -20,14 +20,8 @@
  *
  * *********************************************************************** */
 
-var fs = require("fs");
 var path = require("upath");
 require("@qooxdoo/framework");
-var util = require("../util");
-
-var readFile = util.promisify(fs.readFile);
-var writeFile = util.promisify(fs.writeFile);
-const mkParentPath = util.promisify(util.mkParentPath);
 
 /**
  * Base class for makers; does not include anything about targets, locales, etc (see AbstractAppMaker)
@@ -138,46 +132,6 @@ qx.Class.define("qx.tool.compiler.makers.Maker", {
         throw new Error("Output directory (" + dir + ") is a parent directory of PWD");
       }
       await qx.tool.utils.files.Utils.deleteRecursive(this.getOutputDir());
-    },
-
-    /**
-     * Checks the version used to compile the output directory, and deletes it if it was compiled
-     * by an out of date compiler
-     */
-    checkCompileVersion: async function() {
-      if (this.isNoErase()) {
-        return;
-      }
-      try {
-        var version = await readFile(path.join(this.getOutputDir(), "version.txt"), { encoding: "utf8" });
-        if (version && version.trim() === qx.tool.compiler.Version.VERSION) {
-          return;
-        }
-      } catch (err) {
-        if (err.code !== "ENOENT") {
-          throw err;
-        }
-      }
-      await this.eraseOutputDir();
-    },
-
-    /**
-     * Writes the compiler version into the output directory
-     * @async
-     */
-    writeCompileVersion: function() {
-      return mkParentPath(this.getOutputDir())
-        .then(() => {
-          writeFile(path.join(this.getOutputDir(), "version.txt"), qx.tool.compiler.Version.VERSION, { encoding: "utf8" });
-          let s = {};
-          s["compiler"] = qx.tool.compiler.Version.VERSION;
-          s.libraries = {};
-          let libs = this.getAnalyser().getLibraries();
-          libs.forEach(lib => {
-            s.libraries[lib.getNamespace()] = lib.getVersion();
-          });
-          writeFile(path.join(this.getOutputDir(), "versions.json"), JSON.stringify(s, null, 2), { encoding: "utf8" });
-        });
     },
 
     /**


### PR DESCRIPTION
I don't know if it is ready for merge yet. I opened this PR mostly to get some feedback about the approach I took. Manual testing worked. I plan to write some tests for it.

My main concerns: 

* I introduced a new option `--set-env` to set the applications environment variables. The idea is that since `--set` sets compiler options and the command `set` manages the DB then we wouldn't want to have generic environment variables available to all of our projects. This might introduce vulnerabilities. For example someone may store a security token there, not wanting to be available in every application. How would it be possible to exclude those? Also, the environment variables are set in `compile.json` and may be entered with a command line option. Would it make sense to introduce yet another place in the DB file to store environment variables?

* The parsing code I used in `MConfig.js` is almost identical with the parsing code from [`qx.tool..cli.commands.Command` line 63](https://github.com/voger/qooxdoo-compiler/blob/master/source/class/qx/tool/cli/commands/Command.js#L63). Where would it be a good place to put a function to merge them somehow so it can be a bit more DRY?

Any thoughts?

