### PR TITLE
Support for TC39 proposal plugins

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -308,6 +308,15 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+      "integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
@@ -362,6 +371,14 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+      "integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/core": "^7.5.5",
     "@babel/generator": "^7.5.5",
     "@babel/parser": "^7.5.5",
+    "@babel/plugin-proposal-optional-chaining": "^7.7.5",
     "@babel/plugin-transform-block-scoping": "^7.5.5",
     "@babel/plugin-transform-react-jsx": "^7.3.0",
     "@babel/polyfill": "^7.4.0",

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -467,6 +467,16 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
     createMakersFromConfig: async function(data) {
       const Console = qx.tool.compiler.Console.getInstance();
       var t = this;
+      
+      if (data.babelOptions) {
+        if (!data.babelConfig) {
+          data.babelConfig = { options: data.babelOptions };
+          qx.tool.compiler.Console.print("qx.tool.cli.compile.deprecatedBabelOptions");
+        } else {
+          qx.tool.compiler.Console.print("qx.tool.cli.compile.deprecatedBabelOptionsConflicting");
+        }
+        delete data.babelOptions;
+      }
 
       var argvAppNames = null;
       if (t.argv["app-name"]) {
@@ -718,9 +728,11 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           });
           return dest;
         }
-        let babelOptions = data.babelOptions || {};
-        qx.lang.Object.mergeWith(babelOptions, targetConfig.babelOptions || {});
-        maker.getAnalyser().setBabelOptions(babelOptions);
+        
+        let babelConfig = qx.lang.Object.clone(data.babel || {}, true);
+        babelConfig.options = babelConfig.options || {};
+        qx.lang.Object.mergeWith(babelConfig.options, targetConfig.babelOptions || {});
+        maker.getAnalyser().setBabelConfig(babelConfig);
 
         var addCreatedAt = targetConfig["addCreatedAt"] || t.argv["addCreatedAt"];
         if (addCreatedAt) {
@@ -1047,7 +1059,9 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       "qx.tool.cli.compile.deprecatedCompile": "The configuration setting %1 in compile.json is deprecated",
       "qx.tool.cli.compile.deprecatedCompileSeeOther": "The configuration setting %1 in compile.json is deprecated (see %2)",
       "qx.tool.cli.compile.deprecatedUri": "URIs are no longer set in compile.json, the configuration setting %1=%2 in compile.json is ignored (it's auto detected)",
-      "qx.tool.cli.compile.deprecatedProvidesBoot": "Manifest.Json no longer supports provides.boot - only Applications can have boot; specified in %1"
+      "qx.tool.cli.compile.deprecatedProvidesBoot": "Manifest.Json no longer supports provides.boot - only Applications can have boot; specified in %1",
+      "qx.tool.cli.compile.deprecatedBabelOptions": "Deprecated use of `babelOptions` - these should be moved to `babel.options`",
+      "qx.tool.cli.compile.deprecatedBabelOptionsConflicting": "Conflicting use of `babel.options` and the deprecated `babelOptions` (ignored)"
     }, "warning");
   }
 });

--- a/source/class/qx/tool/compiler/Analyser.js
+++ b/source/class/qx/tool/compiler/Analyser.js
@@ -102,8 +102,8 @@ qx.Class.define("qx.tool.compiler.Analyser", {
       check: "Map"
     },
     
-    /** options sent to babel preset */
-    babelOptions: {
+    /** configuration of babel */
+    babelConfig: {
       init: null,
       nullable: true,
       check: "Object"

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -335,9 +335,25 @@
         "type": "string"
       }
     },
+    "babel": {
+      "type": "object",
+      "properties": {
+        "options": {
+          "type": "object",
+          "description": "Options given to @babel/preset-env. With this options the output type of babel can be defined. For details see here: <https://babeljs.io/docs/en/babel-preset-env#options>. They can be overridden per target."
+        },
+        "plugins": {
+          "type": "object",
+          "description": "List of additional babel plugins to enable, eg TC39 proposals; note that some proposals will work out of the box and some will require upgrades to QxCompiler before they work properly - your mileage may vary.  Each key in this object is the NPM name of the plugin, and the value is either true (enabled), false (ignore), or an object which is options to pass to the preset",
+          "additionalProperties": {
+            "type": [ "boolean", "object" ]
+          }
+        }
+      }
+    },
     "babelOptions": {
       "type": "object",
-      "description": "Options given to @babel/preset-env. With this options the output type of babel can be defined. For details see here: <https://babeljs.io/docs/en/babel-preset-env#options>. They can be overridden per target."
+      "description": "** DEPRECATED - See babel.options instead"
     },
     "jsx": {
       "type": "object",

--- a/source/resource/qx/tool/schema/compile-1-0-0.json
+++ b/source/resource/qx/tool/schema/compile-1-0-0.json
@@ -211,7 +211,8 @@
             "type": "boolean"
           },
           "babelOptions": {
-            "$ref": "#/properties/babelOptions"
+            "type": "object",
+            "description": "Options given to @babel/preset-env. With this options the output type of babel can be defined. For details see here: <https://babeljs.io/docs/en/babel-preset-env#options>. They can be overridden per target."
           },
           "parts": {
             "$ref": "#/properties/parts"
@@ -353,7 +354,8 @@
     },
     "babelOptions": {
       "type": "object",
-      "description": "** DEPRECATED - See babel.options instead"
+      "description": "** DEPRECATED - See babel.options instead",
+      "deprecated": true
     },
     "jsx": {
       "type": "object",

--- a/test/test-deps.js
+++ b/test/test-deps.js
@@ -77,6 +77,11 @@ async function createMaker() {
   let analyser = maker.getAnalyser();
   analyser.addLibrary(await qx.tool.compiler.app.Library.createLibrary("testapp"));
   analyser.addLibrary(await qx.tool.compiler.app.Library.createLibrary(QOOXDOO_PATH));
+  analyser.setBabelConfig({
+    plugins: {
+      "@babel/plugin-proposal-optional-chaining": true
+    }
+  });
   
   return maker;
 }
@@ -224,6 +229,16 @@ test("Checks dependencies and environment settings", assert => {
         assert.ok(arr.length === 0, "unexpected unresolved " + JSON.stringify(arr) + " in testapp.Issue503");
       })
       
+      /*
+       * Test Warnings
+       */
+      .then(src => {
+        var ci = db.classInfo["testapp.Warnings1"];
+        var arr = ci.unresolved||[];
+        assert.ok(arr.length === 0, "unexpected unresolved " + JSON.stringify(arr) + " in testapp.Warnings");
+      })
+      
+
 
       /*
        * Test JSX

--- a/test/testapp/compile.json
+++ b/test/testapp/compile.json
@@ -1,4 +1,9 @@
 {
+  "babel": {
+    "plugins": {
+      "@babel/plugin-proposal-optional-chaining": true
+    }
+  },
   "targets": [
     {
       "type": "source",

--- a/test/testapp/source/class/testapp/Application.js
+++ b/test/testapp/source/class/testapp/Application.js
@@ -179,6 +179,7 @@ qx.Class.define("testapp.Application", {
       new testapp.Issue500();
       new testapp.Issue503();
       new testapp.InnerEs6Classes();
+      new testapp.Warnings1();
       
       qx.core.Assert.assertTrue(TEST_EXTERNAL === "loaded");
       qx.core.Assert.assertTrue(SCRIPT_LOADED === true);
@@ -189,6 +190,17 @@ qx.Class.define("testapp.Application", {
       qx.core.Assert.assertTrue(qx.core.Environment.get("testappLibraryApi") === "one");
       qx.core.Assert.assertTrue(qx.core.Environment.get("testlibCompilerApi") === undefined);
       qx.core.Assert.assertTrue(qx.core.Environment.get("testlibLibraryApi") === "one");
+      
+      const obj = {
+          foo: {
+            bar: {
+              baz: 42,
+            },
+          },
+        };
+
+      qx.core.Assert.assertTrue(obj?.foo?.bar?.baz === 42);
+      qx.core.Assert.assertTrue(obj?.qux?.baz === undefined);
       
       var abc = (<div>Hello World</div>);
     },

--- a/test/testapp/source/class/testapp/Warnings1.js
+++ b/test/testapp/source/class/testapp/Warnings1.js
@@ -1,0 +1,26 @@
+qx.Class.define("testapp.Warnings1", {
+  extend: qx.core.Object,
+  
+  construct(options) {
+    this.base(arguments);
+    
+    let proxyOpts = {
+        proxyReqPathResolver(req) {
+          console.log(`proxyReqPathResolver: ${req.originalUrl}`);
+          return req.originalUrl;
+        },
+        proxyReqOptDecorator(proxyReqOpts, srcReq) {
+          let cookies = srcReq.cookieJarStore && srcReq.cookieJarStore.getAllCookiesSync() || null;
+          if (cookies) {
+            cookies = cookies.map(cookie => cookie.toString());
+            let arr = proxyReqOpts.headers["Set-Cookie"];
+            if (!arr)
+              arr = proxyReqOpts.headers["Set-Cookie"] = [];
+            qx.lang.Array.append(arr, cookies);
+          }
+          console.log(`proxyReqOptDecorator: ${JSON.stringify(proxyReqOpts)}`);
+          return proxyReqOpts;
+        }
+      };
+  }
+});


### PR DESCRIPTION
This adds support for additional, non-standard babel plugins - EG the `@babel/plugin-proposal-*` plug ins which add early proposed additions to javascript.

Not surprisingly this comes with caveats, first of which is that changes to the language may well require an upgrade to QxCompiler itself so that it can recognise the new language construct and act accordingly.  

In many cases, turning on a new plugin that QxCompiler does not support will just cause extra warnings, usually about unresolved symbols because (EG) QxCompiler did not understand a new syntax of declaring the variable in the first place.  But there may be other side effects where the plugin simply cannot work without an upgrade.

So, adding in babel plugins that extend the language is at your own risk, but should be useful.

This PR adds support for the [@babel/plugin-proposal-optional-chaining`](@babel/plugin-proposal-optional-chaining).

To enable this, you need to modify the top level `babel` property, eg:

```
  "babel": {
    "plugins": {
      "@babel/plugin-proposal-optional-chaining": true
    }
  },
```
Note that the old top level `babelOptions` property has been deprecated in favour of `babel.options`
