### PR TITLE
Override default environment

### DIFF
--- a/source/class/qx/tool/cli/commands/MConfig.js
+++ b/source/class/qx/tool/cli/commands/MConfig.js
@@ -209,7 +209,14 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
         config.environment = {};
       }
 
-      qx.lang.Object.mergeWith(config.environment, parsedArgs.environment, true);
+      // Set the environment variables coming from arg in target's
+      // environment object. If that object doesn't exist create one
+      // and assign it to the target.
+      const target = config.targets.find(target =>
+        target.type === config.targetType);
+      target.environment = target.environment || {};
+      qx.lang.Object.mergeWith(target.environment, parsedArgs.environment, true);
+
       if (!config.libraries) {
         config.libraries = [ "." ];
       }

--- a/source/class/qx/tool/cli/commands/MConfig.js
+++ b/source/class/qx/tool/cli/commands/MConfig.js
@@ -209,9 +209,9 @@ qx.Mixin.define("qx.tool.cli.commands.MConfig", {
         config.environment = {};
       }
 
-      // Set the environment variables coming from arg in target's
-      // environment object. If that object doesn't exist create one
-      // and assign it to the target.
+      // Set the environment variables coming from command line arguments
+      // in target's environment object. If that object doesn't exist create
+      // one and assign it to the target.
       const target = config.targets.find(target =>
         target.type === config.targetType);
       target.environment = target.environment || {};


### PR DESCRIPTION
So far the `--set-env` command line option assigns environment options but doesn't override the options set by the individual target. This PR fixes that. 

Environment settings coming from command line must override the settings set in `compile.json`. This PR merges the incoming values from the argv with those of the target's that is to be compiled right now. If that target doesn't have an `environment` object, one is created and assigned to it. 

The reason for not using the global environment when target's environment doesn't exist is that the target's environment takes precedence over the global environment. 