### PR TITLE
add qx test

### DIFF
--- a/source/class/qx/tool/cli/Cli.js
+++ b/source/class/qx/tool/cli/Cli.js
@@ -63,6 +63,7 @@ qx.Class.define("qx.tool.cli.Cli", {
           "Create",
           "Lint",
           "Run",
+          "Test",
           "Serve"
         ],
         "qx.tool.cli.commands");

--- a/source/class/qx/tool/cli/api/LibraryApi.js
+++ b/source/class/qx/tool/cli/api/LibraryApi.js
@@ -47,7 +47,40 @@ qx.Class.define("qx.tool.cli.api.LibraryApi", {
      */
     async afterLibrariesLoaded() {
       // Nothing
-    }
+    },
+  
+    /**
+     * 
+     * helper to load an npm module. Check if it can be loaded before
+     * If not install the module with 'npm install --no-save --no-package-lock' to the current library
+     * 
+     * @param module {String} module to check
+     */
+    require: function(module) {
+        try {
+          require.resolve(module);
+        } catch (e) {
+          if ( e.code === 'MODULE_NOT_FOUND' ) {
+            this.loadNpmModule(module);
+          }
+        }
+        return require(module);
+     },
+     /**
+      * 
+      * install an npm module with 'npm install --no-save --no-package-lock' to the current library
+      * 
+      * @param module {String} module to load
+      */
+     loadNpmModule: function(module) {
+       const {execSync} = require("child_process");
+       let s = `npm install --no-save --no-package-lock ${module}`;
+       qx.tool.compiler.Console.info(s);
+       execSync(s, {
+         stdio: "inherit"
+       });
+     },
+	
     
   }
 });

--- a/source/class/qx/tool/cli/api/LibraryApi.js
+++ b/source/class/qx/tool/cli/api/LibraryApi.js
@@ -57,29 +57,29 @@ qx.Class.define("qx.tool.cli.api.LibraryApi", {
      * @param module {String} module to check
      */
     require: function(module) {
-        try {
-          require.resolve(module);
-        } catch (e) {
-          if ( e.code === 'MODULE_NOT_FOUND' ) {
-            this.loadNpmModule(module);
-          }
+      try {
+        require.resolve(module);
+      } catch (e) {
+        if (e.code === "MODULE_NOT_FOUND") {
+          this.loadNpmModule(module);
         }
-        return require(module);
-     },
-     /**
+      }
+      return require(module);
+    },
+    /**
       * 
       * install an npm module with 'npm install --no-save --no-package-lock' to the current library
       * 
       * @param module {String} module to load
       */
-     loadNpmModule: function(module) {
-       const {execSync} = require("child_process");
-       let s = `npm install --no-save --no-package-lock ${module}`;
-       qx.tool.compiler.Console.info(s);
-       execSync(s, {
-         stdio: "inherit"
-       });
-     },
+    loadNpmModule: function(module) {
+      const {execSync} = require("child_process");
+      let s = `npm install --no-save --no-package-lock ${module}`;
+      qx.tool.compiler.Console.info(s);
+      execSync(s, {
+        stdio: "inherit"
+      });
+    }
 	
     
   }

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -616,7 +616,6 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           });
           if (!hasExplicitDefaultApp && (targetConfig.appConfigs.length > 1)) {
             targetConfig.defaultAppConfig = targetConfig.appConfigs[0];
-            qx.tool.compiler.Console.print("qx.tool.cli.compile.selectingDefaultApp", targetConfig.defaultAppConfig.name);
           }
         }
       });

--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -104,6 +104,15 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
     },
     
     /**
+     * 
+     * returns the showStartpage flag
+     * 
+     */
+    showStartpage: function() {
+       return this.__showStartpage;
+    },
+
+    /**
      * Runs the web server
      * 
      * @ignore qx.tool.$$resourceDir
@@ -129,16 +138,15 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       if (!defaultMaker && (apps.length === 1)) {
         defaultMaker = firstMaker;
       }
-
-      let showStartpage = this.argv.showStartpage;
-      if (showStartpage === null) {
-        showStartpage = apps.length > 1;
+      
+      this.__showStartpage = this.argv.showStartpage;
+      if (this.__showStartpage === null) {
+        this.__showStartpage = apps.length > 1;
       }
       var config = this._getConfig();
-
       const app = express();
       const website = new qx.tool.utils.Website();
-      if (!showStartpage) {
+      if (!this.__showStartpage) {
         app.use("/", express.static(defaultMaker.getTarget().getOutputDir()));
       } else {
         let s = await this.getAppQxPath();
@@ -191,7 +199,11 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
           this.fireEvent("started");
         });
       });
-    }
+    },
+    
+    __showStartpage: null
+
+
   },
 
   defer: function(statics) {

--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -109,7 +109,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
      * 
      */
     showStartpage: function() {
-       return this.__showStartpage;
+      return this.__showStartpage;
     },
 
     /**

--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -71,6 +71,12 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       };
     }
   },
+  events: {
+    /**
+     * Fired when server is started
+    */
+    "started": "qx.event.type.Event"
+  },
 
   members: {
     /** @type {qx.tool.utils.Website} the Website instance */
@@ -180,8 +186,10 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
             qx.tool.compiler.Console.log("Error when starting web server: " + e);
           }
         });
-        server.listen(config.serve.listenPort, () =>
-          qx.tool.compiler.Console.print("qx.tool.cli.serve.webStarted", "http://localhost:" + config.serve.listenPort));
+        server.listen(config.serve.listenPort, () => {
+          qx.tool.compiler.Console.print("qx.tool.cli.serve.webStarted", "http://localhost:" + config.serve.listenPort);
+          this.fireEvent("started");
+        });
       });
     }
   },

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -64,7 +64,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
     /**
      * Fired to start tests
     */
-    "runTests": "qx.event.type.Event"
+    "runTests": "qx.event.type.Data"
   },
 
   members: {
@@ -76,8 +76,11 @@ qx.Class.define("qx.tool.cli.commands.Test", {
       this.argv["machine-readable"] = false;
       this.argv["feedback"] = false;
       this.addListener("started", async () =>  {
-         await this.fireEvent("runTests");
-         process.exit(0);
+        let result = {errorCode: 0};
+        let res = this.fireDataEvent("runTests", result);
+        res.then(() => {
+          process.exit(result.errorCode);          
+        });
       });
       await this.base(arguments);
     }

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -75,11 +75,18 @@ qx.Class.define("qx.tool.cli.commands.Test", {
       this.argv.watch = false;
       this.argv["machine-readable"] = false;
       this.argv["feedback"] = false;
-      this.addListener("started", () =>  {
+      this.addListener("making", () => {
         if (!this.hasListener("runTests")) {
-          qx.tool.compiler.Console.error("No test runner registered!");
+          qx.tool.compiler.Console.error(
+              `No test runner registered!
+               Please register a testrunner, e.g. testtapper with:
+               qx contrib install @qooxdoo/qxl.testtapper
+              `
+          );
           process.exit(-1);
         }
+      });
+      this.addListener("started", () =>  {
         let result = {errorCode: 0};
         let res = this.fireDataEvent("runTests", result);
         res.then(() => {

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -41,7 +41,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
         describe: "only run tests of this method",
         type: "string"
       }
-},
+    },
 
     getYargsCommand: function() {
       return {
@@ -78,7 +78,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
       this.addListener("making", () => {
         if (!this.hasListener("runTests")) {
           qx.tool.compiler.Console.error(
-              `No test runner registered!
+            `No test runner registered!
                Please register a testrunner, e.g. testtapper with:
                qx contrib install @qooxdoo/qxl.testtapper
               `
@@ -86,7 +86,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
           process.exit(-1);
         }
       });
-      this.addListener("started", () =>  {
+      this.addListener("started", () => {
         let result = {errorCode: 0};
         let res = this.fireDataEvent("runTests", result);
         res.then(() => {

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -75,7 +75,11 @@ qx.Class.define("qx.tool.cli.commands.Test", {
       this.argv.watch = false;
       this.argv["machine-readable"] = false;
       this.argv["feedback"] = false;
-      this.addListener("started", async () =>  {
+      this.addListener("started", () =>  {
+        if (!this.hasListener("runTests")) {
+          qx.tool.compiler.Console.error("No test runner registered!");
+          process.exit(-1);
+        }
         let result = {errorCode: 0};
         let res = this.fireDataEvent("runTests", result);
         res.then(() => {

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -1,0 +1,95 @@
+/* ************************************************************************
+
+   qooxdoo - the new era of web development
+
+   http://qooxdoo.org
+
+   Copyright:
+     2020 Henner Kollmann
+
+   License:
+     MIT: https://opensource.org/licenses/MIT
+     See the LICENSE file in the project"s top-level directory for details.
+
+
+************************************************************************ */
+require("./Serve");
+
+/**
+ * Compiles the project and serves it up as a web page
+ */
+qx.Class.define("qx.tool.cli.commands.Test", {
+  extend: qx.tool.cli.commands.Serve,
+
+  statics: {
+
+    YARGS_BUILDER: {
+      verbose: {
+        describe: "Verbose logging",
+        alias: "v",
+        type: "boolean"
+      },
+      diag: {
+        describe: "show diagnostic output",
+        type: "boolean"
+      },
+      class: {
+        describe: "only run tests of this class",
+        type: "string"
+      },
+      method: {
+        describe: "only run tests of this method",
+        type: "string"
+      }
+},
+
+    getYargsCommand: function() {
+      return {
+        command   : "test [configFile]",
+        describe  : "run test for current project",
+        builder   : Object.assign(qx.tool.cli.commands.Compile.YARGS_BUILDER, qx.tool.cli.commands.Serve.YARGS_BUILDER, qx.tool.cli.commands.Test.YARGS_BUILDER),
+        handler: function(argv) {
+          return new qx.tool.cli.commands.Test(argv)
+            .process()
+            .catch(e => {
+              qx.tool.compiler.Console.error(e.stack || e.message);
+              process.exit(1);
+            });
+        }
+      };
+    }
+  },
+
+  events: {
+    /**
+     * Fired to start tests
+    */
+    "runTests": "qx.event.type.Event"
+  },
+
+  members: {
+    /*
+     * @Override
+     */
+    process: async function() {
+      this.argv.watch = false;
+      this.argv["machine-readable"] = false;
+      this.argv["feedback"] = false;
+      this.addListener("started", async () =>  {
+         await this.fireEvent("runTests");
+         process.exit(0);
+      });
+      await this.base(arguments);
+    }
+  },
+
+
+  defer: function(statics) {
+    qx.tool.compiler.Console.addMessageIds({
+      "qx.tool.cli.test.noAppName": "Cannot run anything because the config.json does not specify a unique application name",
+      "qx.tool.cli.test.tooManyMakers": "Cannot run anything because multiple targets are detected",
+      "qx.tool.cli.test.tooManyApplications": "Cannot run anything because multiple applications are detected"
+    });
+  }
+});
+

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -8,10 +8,7 @@ const qx = require("@qooxdoo/framework");
 test("Issue553", async assert => {
   try {
     await deleteRecursive("issue553/compiled");
-    let result = await runCompiler("issue553", "compile");
-    let messages = result.messages.filter(msg => msg.id == "qx.tool.cli.compile.selectingDefaultApp");
-    assert.ok(messages.length == 1);
-    assert.ok(messages[0].args[0] === "issue553one");
+    await runCompiler("issue553", "compile");
     assert.ok(fs.existsSync("issue553/compiled/source/index.html"));
     let indexHtml = await fsPromises.readFile("issue553/compiled/source/index.html", "utf8");
     assert.ok(!!indexHtml.match(/issue553one\/boot.js/m));


### PR DESCRIPTION
This adds qx test to the compiler.

To use qx test you need to add a test contrib to your app, e.g. testtapper.

Idea:
qx serve fires a new event after server start. qx test listen for this event and fires an event runTests. 
After this the process is finished.

The test contrib has to register a event handler to runTests in his compile.js file.
This event handler has to return a promise which is resolved after all tests are done.

See testtapper contrib for an example.
