### PR TITLE
add beforeStart event 

### DIFF
--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -73,9 +73,18 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
   },
   events: {
     /**
+     * Fired before server start
+     * 
+     *  data: {
+     *    server: the http server
+     *    application: the used express server instance
+     *  }
+     */
+    "beforeStart": "qx.event.type.Data",
+    /**
      * Fired when server is started
     */
-    "started": "qx.event.type.Event"
+    "afterStart": "qx.event.type.Event"
   },
 
   members: {
@@ -186,6 +195,10 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       }
       this.addListenerOnce("made", e => {
         let server = http.createServer(app);
+        this.fireDataEvent("beforeStart", {
+          server: server,
+          application: app
+        });
         server.on("error", e => {
           if (e.code === "EADDRINUSE") {
             qx.tool.compiler.Console.print("qx.tool.cli.serve.webAddrInUse", config.serve.listenPort);
@@ -196,7 +209,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
         });
         server.listen(config.serve.listenPort, () => {
           qx.tool.compiler.Console.print("qx.tool.cli.serve.webStarted", "http://localhost:" + config.serve.listenPort);
-          this.fireEvent("started");
+          this.fireEvent("afterStart");
         });
       });
     },

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -90,7 +90,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
           process.exit(-1);
         }
       });
-      this.addListener("started", () => {
+      this.addListener("afterStart", () => {
         let result = {errorCode: 0};
         let res = this.fireDataEvent("runTests", result);
         res.then(() => {


### PR DESCRIPTION
- with this it's possible to add own extensions to express module
rename started event to afterStart for naming consistence