### PR TITLE
fix startpage in serve

### DIFF
--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -150,7 +150,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       
       this.__showStartpage = this.argv.showStartpage;
       if (this.__showStartpage === null) {
-        this.__showStartpage = apps.length > 1;
+        this.__showStartpage = defaultMaker === null;
       }
       var config = this._getConfig();
       const app = express();


### PR DESCRIPTION
   - startpage should'nt be shown if there is an default app.
   - startpage should be shown if there is no app too.