### PR TITLE
Fix sass bug

### DIFF
--- a/source/class/qx/tool/compiler/resources/ScssFile.js
+++ b/source/class/qx/tool/compiler/resources/ScssFile.js
@@ -98,7 +98,7 @@ qx.Class.define("qx.tool.compiler.resources.ScssFile", {
             if (!contents) {
               let tmp = this.__importAs[url];
               if (tmp) {
-                contents = this.__sourceFiles[url];
+                contents = this.__sourceFiles[tmp];
               }
             }
             return contents ? { contents } : null;

--- a/test/test-deps.js
+++ b/test/test-deps.js
@@ -316,7 +316,7 @@ test("Checks dependencies and environment settings", assert => {
        */
       .then(async () => {
         src = await readFile("unit-tests-output/resource/testapp/scss/root.css", "utf8");
-        assert.ok(src.match(/url\(\.\.\/sub5\/image.png\)/), "Resource SCSS");
+        assert.ok(src.match(/url\(\"sub5\/image.png\"\)/), "Resource SCSS");
       })
 
       .then(() => assert.end())


### PR DESCRIPTION
fixes a bug where the sass file would not be found if the file to be imported is "_filename.scss" and it is imported via `@import "filename";`
