### PR TITLE
Fixes the regression where the command was not available in `LibraryApi.load`

### DIFF
--- a/source/class/qx/tool/cli/api/AbstractApi.js
+++ b/source/class/qx/tool/cli/api/AbstractApi.js
@@ -34,6 +34,14 @@ qx.Class.define("qx.tool.cli.api.AbstractApi", {
   },
   
   members: {
+    /**
+     * Called by the compiler API during initialisation - this is an ideal
+     * place to install additional commands, because a command has not yet
+     * been selected 
+     */
+    async initialize() {
+      // Nothing
+    }
   }
 });
 

--- a/source/class/qx/tool/cli/api/CompilerApi.js
+++ b/source/class/qx/tool/cli/api/CompilerApi.js
@@ -30,9 +30,8 @@ const fs = qx.tool.utils.Promisify.fs;
 qx.Class.define("qx.tool.cli.api.CompilerApi", {
   extend: qx.tool.cli.api.AbstractApi,
   
-  construct: function(command) {
+  construct: function() {
     this.base(arguments);
-    this.__command = command;
     this.__libraryApis = {};
   },
   
@@ -45,12 +44,19 @@ qx.Class.define("qx.tool.cli.api.CompilerApi", {
     
     /** Configuration data for the compiler */
     configuration: {
+    },
+    
+    /** The current command */
+    command: {
+      init: null,
+      nullable: true,
+      check: "qx.tool.cli.commands.Command",
+      event: "changeCommand"
     }
   },
-  
+
   members: {
     __libraryApis: null,
-    __command: null,
     
     /**
      * Loads the configuration data
@@ -63,15 +69,6 @@ qx.Class.define("qx.tool.cli.api.CompilerApi", {
       }
       this.setConfiguration(config);
       return config;
-    },
-    
-    /**
-     * Returns the command
-     * 
-     * @return {qx.tool.cli.commands.Command} the CLI command
-     */
-    getCommand() {
-      return this.__command;
     },
     
     /**

--- a/source/class/qx/tool/cli/api/LibraryApi.js
+++ b/source/class/qx/tool/cli/api/LibraryApi.js
@@ -50,7 +50,7 @@ qx.Class.define("qx.tool.cli.api.LibraryApi", {
     async afterLibrariesLoaded() {
       // Nothing
     },
-  
+    
     /**
      * 
      * helper to load an npm module. Check if it can be loaded before

--- a/source/class/qx/tool/cli/commands/Clean.js
+++ b/source/class/qx/tool/cli/commands/Clean.js
@@ -39,14 +39,6 @@ qx.Class.define("qx.tool.cli.commands.Clean", {
             alias : "v",
             describe: "Verbose logging"
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.Clean(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/Command.js
+++ b/source/class/qx/tool/cli/commands/Command.js
@@ -56,7 +56,7 @@ qx.Class.define("qx.tool.cli.commands.Command", {
       qx.tool.cli.LogAppender.setMinLevel("debug");
     }
   },
-
+  
   members: {
     argv: null,
     compileJs: null,

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -157,15 +157,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
       return {
         command   : "compile [configFile]",
         describe  : "compiles the current application, using compile.json",
-        builder   : qx.tool.cli.commands.Compile.YARGS_BUILDER,
-        handler: function(argv) {
-          return new qx.tool.cli.commands.Compile(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error("Error: " + (e.stack || e.message));
-              process.exit(1);
-            });
-        }
+        builder   : qx.tool.cli.commands.Compile.YARGS_BUILDER
       };
     }
 

--- a/source/class/qx/tool/cli/commands/Config.js
+++ b/source/class/qx/tool/cli/commands/Config.js
@@ -68,6 +68,7 @@ qx.Class.define("qx.tool.cli.commands.Config", {
             }, argv => run(argv, "cmdList"));
         },
         handler   : function(argv) {
+          // Nothing
         }
       };
     },

--- a/source/class/qx/tool/cli/commands/Create.js
+++ b/source/class/qx/tool/cli/commands/Create.js
@@ -20,7 +20,6 @@ require("./Package");
 
 require("@qooxdoo/framework");
 const fs = require("fs");
-const process = require("process");
 const path = require("upath");
 const inquirer = require("inquirer");
 
@@ -80,14 +79,6 @@ qx.Class.define("qx.tool.cli.commands.Create", {
             alias : "v",
             describe: "Verbose logging"
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.Create(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     },

--- a/source/class/qx/tool/cli/commands/Lint.js
+++ b/source/class/qx/tool/cli/commands/Lint.js
@@ -77,14 +77,6 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
             alias: "q",
             describe: "No output"
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.Lint(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.log(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }
@@ -150,12 +142,14 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
      */
     async __addGlobals(data) {
       let result = {};
-      await qx.Promise.all(data.libraries.map(async dir => {
-        let lib = await qx.tool.compiler.app.Library.createLibrary(dir);
-        let s = lib.getNamespace();
-        let libs = s.split(".");
-        result[libs[0]] = false;
-      }));
+      if (data.libraries) {
+        await qx.Promise.all(data.libraries.map(async dir => {
+          let lib = await qx.tool.compiler.app.Library.createLibrary(dir);
+          let s = lib.getNamespace();
+          let libs = s.split(".");
+          result[libs[0]] = false;
+        }));
+      }
       return result;
     },
 

--- a/source/class/qx/tool/cli/commands/Pkg.js
+++ b/source/class/qx/tool/cli/commands/Pkg.js
@@ -49,6 +49,7 @@ qx.Class.define("qx.tool.cli.commands.Pkg", {
             .help();
         },
         handler : function(argv) {
+          // Nothing
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/Run.js
+++ b/source/class/qx/tool/cli/commands/Run.js
@@ -47,15 +47,7 @@ qx.Class.define("qx.tool.cli.commands.Run", {
       return {
         command   : "run [configFile]",
         describe  : "runs a server application (written in node) with continuous compilation, using compile.json",
-        builder   : Object.assign(qx.tool.cli.commands.Compile.YARGS_BUILDER, qx.tool.cli.commands.Run.YARGS_BUILDER),
-        handler: function(argv) {
-          return new qx.tool.cli.commands.Run(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
-        }
+        builder   : Object.assign(qx.tool.cli.commands.Compile.YARGS_BUILDER, qx.tool.cli.commands.Run.YARGS_BUILDER)
       };
     }
   },

--- a/source/class/qx/tool/cli/commands/Serve.js
+++ b/source/class/qx/tool/cli/commands/Serve.js
@@ -59,15 +59,7 @@ qx.Class.define("qx.tool.cli.commands.Serve", {
       return {
         command   : "serve [configFile]",
         describe  : "runs a webserver to run the current application with continuous compilation, using compile.json",
-        builder   : Object.assign(qx.tool.cli.commands.Compile.YARGS_BUILDER, qx.tool.cli.commands.Serve.YARGS_BUILDER),
-        handler: function(argv) {
-          return new qx.tool.cli.commands.Serve(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
-        }
+        builder   : Object.assign(qx.tool.cli.commands.Compile.YARGS_BUILDER, qx.tool.cli.commands.Serve.YARGS_BUILDER)
       };
     }
   },

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -67,12 +67,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
           if (!argv.configFile && fs.existsSync(path.join(process.cwd(), qx.tool.cli.commands.Test.CONFIG_FILENAME))) {
             argv.configFile = qx.tool.cli.commands.Test.CONFIG_FILENAME;
           }
-          return new qx.tool.cli.commands.Test(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
+          return qx.tool.cli.Cli.getInstance().processCommand(new qx.tool.cli.commands.Test(argv));
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/add/Class.js
+++ b/source/class/qx/tool/cli/commands/add/Class.js
@@ -72,14 +72,6 @@ qx.Class.define("qx.tool.cli.commands.add.Class", {
           //   alias : "v",
           //   describe: 'Verbose logging'
           // }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.add.Class(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/add/Script.js
+++ b/source/class/qx/tool/cli/commands/add/Script.js
@@ -54,14 +54,6 @@ qx.Class.define("qx.tool.cli.commands.add.Script", {
             alias: "I",
             describe: "Do not prompt user"
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.add.Script(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/package/Install.js
+++ b/source/class/qx/tool/cli/commands/package/Install.js
@@ -75,14 +75,6 @@ qx.Class.define("qx.tool.cli.commands.package.Install", {
             nargs: 1,
             describe: "Install a library/the given library from a local path"
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.package.Install(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/package/List.js
+++ b/source/class/qx/tool/cli/commands/package/List.js
@@ -91,14 +91,6 @@ qx.Class.define("qx.tool.cli.commands.package.List", {
             alias: "u",
             describe: "Output only the GitHub URIs of the packages which are used to install the packages. Implies --noheaders and --libraries."
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.package.List(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/package/Migrate.js
+++ b/source/class/qx/tool/cli/commands/package/Migrate.js
@@ -51,14 +51,6 @@ qx.Class.define("qx.tool.cli.commands.package.Migrate", {
             alias: "q",
             describe: "No output"
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.package.Migrate(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/package/Publish.js
+++ b/source/class/qx/tool/cli/commands/package/Publish.js
@@ -83,14 +83,6 @@ qx.Class.define("qx.tool.cli.commands.package.Publish", {
             alias: "i",
             describe: "Create an index file (qooxdoo.json) with paths to Manifest.json files"
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.package.Publish(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/package/Remove.js
+++ b/source/class/qx/tool/cli/commands/package/Remove.js
@@ -19,7 +19,6 @@ require("../Package");
 
 require("@qooxdoo/framework");
 const fs = require("fs");
-const process = require("process");
 const path = require("upath");
 const rimraf = require("rimraf");
 
@@ -43,14 +42,6 @@ qx.Class.define("qx.tool.cli.commands.package.Remove", {
             alias: "q",
             describe: "No output"
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.package.Remove(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/package/Update.js
+++ b/source/class/qx/tool/cli/commands/package/Update.js
@@ -65,14 +65,6 @@ qx.Class.define("qx.tool.cli.commands.package.Update", {
             alias: "q",
             describe: "No output"
           }
-        },
-        handler: function(argv) {
-          return new qx.tool.cli.commands.package.Update(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/source/class/qx/tool/cli/commands/package/Upgrade.js
+++ b/source/class/qx/tool/cli/commands/package/Upgrade.js
@@ -55,14 +55,6 @@ qx.Class.define("qx.tool.cli.commands.package.Upgrade", {
             alias: "p",
             describe: "Use prereleases if available"
           }
-        },
-        handler: function (argv) {
-          return new qx.tool.cli.commands.package.Upgrade(argv)
-            .process()
-            .catch(e => {
-              qx.tool.compiler.Console.error(e.stack || e.message);
-              process.exit(1);
-            });
         }
       };
     }

--- a/test/testapp/compile.js
+++ b/test/testapp/compile.js
@@ -25,8 +25,10 @@ qx.Class.define("qxl.compilertests.testapp.LibraryApi", {
     
     async load() {
       let command = this.getCompilerApi().getCommand();
-      command.addListener("making", () => this._onMaking());
-      command.addListener("checkEnvironment", e => this._appCompiling(e.getData().application, e.getData().environment));
+      if (command instanceof qx.tool.cli.commands.Compile) {
+        command.addListener("making", () => this._onMaking());
+        command.addListener("checkEnvironment", e => this._appCompiling(e.getData().application, e.getData().environment));
+      }
     },
     
     _onMaking() {

--- a/test/testlib/compile.js
+++ b/test/testlib/compile.js
@@ -19,10 +19,10 @@ qx.Class.define("qxl.compilertests.testlib.LibraryApi", {
   extend: qx.tool.cli.api.LibraryApi,
   
   members: {
-    async load() {
-      let command = this.getCompilerApi().getCommand();
-      command.addListener("checkEnvironment", e => this._appCompiling(e.getData().application, e.getData().environment));
-      
+    /*
+     * @Override
+     */
+    async initialize() {
       let cli = qx.tool.cli.Cli.getInstance();
       cli.yargs.command({
         command: "testlib <message> [options]",
@@ -40,6 +40,15 @@ qx.Class.define("qxl.compilertests.testlib.LibraryApi", {
           console.log(`The commmand testlib; message=${argv.message}, type=${argv.type}`);
         }
       });
+    },
+    
+    /*
+     * @Override
+     */
+    async load() {
+      let command = this.getCompilerApi().getCommand();
+      if (command)
+        command.addListener("checkEnvironment", e => this._appCompiling(e.getData().application, e.getData().environment));
     },
     
     _appCompiling(application, environment) {


### PR DESCRIPTION
Fixes https://github.com/qooxdoo/qooxdoo-compiler/issues/643

However, this recent change means that the LibraryApi.load is always called, regardless of the command - so it is important to check the type of the command, eg to make sure it is `instanceof qx.tool.cli.commands.Compile`.

Docs coming in a minute