### PR TITLE
fixes a bug where `qx compile` would try to install libraries unnecessarily

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1075,9 +1075,9 @@
       "integrity": "sha512-s+mHk2WWGBVhspJ5Xqj9XPrDJOhNZhfHVmrZNOLS9d1BcXSwo89NRWz4mJrOIYpDXxE7B7sekPSB4klCC6Qd1w=="
     },
     "@qooxdoo/framework": {
-      "version": "6.0.0-beta-20190618-2102",
-      "resolved": "https://registry.npmjs.org/@qooxdoo/framework/-/framework-6.0.0-beta-20190618-2102.tgz",
-      "integrity": "sha512-ALi1YNkPrgEVyj3bfAuRkc+L7Ka+dlXqAhEDUZwgMFHpe1W8HKVrRpvOYdMfpMdCj98VXDcA596wKxXZNeLZZw=="
+      "version": "6.0.0-beta-20200401-1413",
+      "resolved": "https://registry.npmjs.org/@qooxdoo/framework/-/framework-6.0.0-beta-20200401-1413.tgz",
+      "integrity": "sha512-B3Aje+1bER2zGcF9/LW1Yd9//2hx2o3DIz0z6EPUb8AQCYTdX2me33d4J545A9QXJWgF0nbaZ2a7pcwpRmhrNA=="
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@qooxdoo/eslint-config-jsdoc-disable": "^1.0.1",
     "@qooxdoo/eslint-config-qx": "1.2.1",
     "@qooxdoo/eslint-plugin-qx": "^1.2.4",
-    "@qooxdoo/framework": "^6.0.0-beta",
+    "@qooxdoo/framework": "6.0.0-beta-20200401-1413",
     "ajv": "^6.10.2",
     "app-module-path": "^2.2.0",
     "async": "^2.6.1",

--- a/source/class/qx/tool/cli/commands/Compile.js
+++ b/source/class/qx/tool/cli/commands/Compile.js
@@ -860,9 +860,16 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
             requires["@qooxdoo/framework"] = range;
           }
         }
-        let requires_uris = Object.getOwnPropertyNames(requires).filter(name => !name.startsWith("qooxdoo-") && name !== "@qooxdoo/framework" && name !== "@qooxdoo/compiler");
+        
+        // Find the libraries that we need, not including the libraries which we have been given explicitly 
+        //  in the compile.json's `libraries` property
+        let requires_uris = Object.getOwnPropertyNames(requires)
+          .filter(uri => !libs.find(lib => lib.getLibraryInfo().name == uri));
+        
+        let urisToInstall = requires_uris.filter(name => !name.startsWith("qooxdoo-") && name !== "@qooxdoo/framework" && name !== "@qooxdoo/compiler");
+        
         let pkg_libs = Object.getOwnPropertyNames(packages);
-        if (requires_uris.length > 0 && pkg_libs.length === 0) {
+        if (urisToInstall.length > 0 && pkg_libs.length === 0) {
           // if we don't have package data
           if (this.argv.download) {
             // but we're instructed to download the libraries
@@ -880,7 +887,7 @@ qx.Class.define("qx.tool.cli.commands.Compile", {
           }
         }
 
-        for (let reqUri of Object.getOwnPropertyNames(requires)) {
+        for (let reqUri of requires_uris) {
           let requiredRange = requires[reqUri];
           const rangeIsCommitHash = /^[0-9a-f]{40}$/.test(requiredRange);
           switch (reqUri) {


### PR DESCRIPTION
fixes a bug where `qx compile` would try to install libraries which were already listed in `compile.json`'s `"libraries": []` key, but which had not been installed by `qx package`.

The bug meant that `qx compile` would defer to `qx package install` and then output a message:
```
$ qx compile
Error: Added missing library information from Manifest. Please restart the compilation.
```

In my case, the defer to qx install` did nothing (presumably because the library *is* available), so compilation was permanently blocked