### PR TITLE
FOR DISCUSSION ONLY:

### DIFF
--- a/source/class/qx/tool/compiler/targets/Target.js
+++ b/source/class/qx/tool/compiler/targets/Target.js
@@ -670,6 +670,7 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
 
       let pathToTarget = path.relative(path.join(t.getOutputDir(), t.getProjectDir(application)), t.getOutputDir()) + "/";
       let TEMPLATE_VARS = {
+        "compileTime": Date.now(),
         "resourcePath": pathToTarget + "resource/",
         "targetPath": pathToTarget,
         "appPath": "",
@@ -740,6 +741,7 @@ qx.Class.define("qx.tool.compiler.targets.Target", {
       if (application.getWriteIndexHtmlToRoot()) {
         pathToTarget = "";
         TEMPLATE_VARS = {
+          "compileTime": Date.now(),
           "resourcePath": "resource/",
           "targetPath": "",
           "appPath": t.getProjectDir(application) + "/",

--- a/source/resource/qx/tool/cli/templates/loader/loader-browser.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/loader/loader-browser.tmpl.js
@@ -121,9 +121,10 @@ qx.$$loader = {
       } else {
         euri = qx.$$appRoot + compressedUris[i];
       }
-      if (qx.$$loader.addNoCacheParam) {
-        euri += "?nocache=" + Math.random();
-      }
+//      if (qx.$$loader.addNoCacheParam) {
+//        euri += "?nocache=" + Math.random();
+//      }
+      euri += "?nocache=" + GLOBALCOMPILETIME;
       %{DecodeUrisPlug}
       uris.push(euri);
     }


### PR DESCRIPTION
load scripts using a fixed cache value defined as the compile time to solve caching issues. This PR only works with the following script added to index.html:
<script>
window.GLOBALCOMPILETIME = ${compileTime};
</script>