### PR TITLE
fix for #662: When a class file has Windows-style line endings (CR/LF…

### DIFF
--- a/source/class/qx/tool/cli/commands/Command.js
+++ b/source/class/qx/tool/cli/commands/Command.js
@@ -273,7 +273,7 @@ qx.Class.define("qx.tool.cli.commands.Command", {
         });
         exe.on("close", code => {
           if (code !== 0) {
-            let message = `Error executing ${cmd.join(" ")}. Use --verbose to see what went wrong.`;
+            let message = `Error executing '${cmd} ${args.join(" ")}'. Use --verbose to see what went wrong.`;
             throw new qx.tool.utils.Utils.UserError(message);
           } else {
             resolve(0);

--- a/source/class/qx/tool/compiler/jsdoc/Parser.js
+++ b/source/class/qx/tool/compiler/jsdoc/Parser.js
@@ -47,7 +47,7 @@ qx.Class.define("qx.tool.compiler.jsdoc.Parser", {
       // special handling for code section
       comment = comment.replace(/@([^@}\n\r]*)@/g, "<code>$1</code>");
       // Strip optional leading * 
-      comment = comment.replace(/^\s*\*/mg, "");
+      comment = comment.replace(/^[ \t]*\*/mg, "");
       // special handling for as markdown lists - * in qooxdoo
       comment = comment.replace(/^\s*\*/mg, "*");
       comment = comment.replace(/^\s*\*\*\*\*/mg, "\t\t\t*");


### PR DESCRIPTION
…) the @asset annotation does not always work.