### PR TITLE
Make "requires" optional

### DIFF
--- a/source/resource/qx/tool/schema/Manifest-1-0-0.json
+++ b/source/resource/qx/tool/schema/Manifest-1-0-0.json
@@ -6,7 +6,6 @@
   "type": "object",
   "required": [
     "provides",
-    "requires",
     "$schema"
   ],
   "additionalProperties": false,


### PR DESCRIPTION
There are libraries that do not depend on anything, like the framework. Therefore "requires" needs to be optional

See https://github.com/qooxdoo/qooxdoo/pull/9945#issuecomment-621816963