### PR TITLE
Fixed error message that mentions deployDir parameter whereas it shou…

### DIFF
--- a/source/class/qx/tool/cli/commands/Deploy.js
+++ b/source/class/qx/tool/cli/commands/Deploy.js
@@ -191,7 +191,7 @@ qx.Class.define("qx.tool.cli.commands.Deploy", {
 
   defer: function(statics) {
     qx.tool.compiler.Console.addMessageIds({
-      "qx.tool.cli.deploy.deployDirNotSpecified": "No deploy dir configured! Use --out parameter or deployDir in compile.json."      
+      "qx.tool.cli.deploy.deployDirNotSpecified": "No deploy dir configured! Use --out parameter or deployPath target property in compile.json."
     }, "error");
     qx.tool.compiler.Console.addMessageIds({
       "qx.tool.cli.deploy.sourceMapsNotSpecified": "Source maps are not being deployed, see --source-maps command line option",


### PR DESCRIPTION
…ld be deployPath instead.

While here, enhance the message so it is clear in what place in the compile.json this property should be placed.