### PR TITLE
Allow empty requires.@qooxdoo/compiler and requires.@qooxdoo/framework ranges in Manifest

### DIFF
--- a/source/class/qx/tool/cli/commands/package/Migrate.js
+++ b/source/class/qx/tool/cli/commands/package/Migrate.js
@@ -143,7 +143,7 @@ qx.Class.define("qx.tool.cli.commands.package.Migrate", {
           for (let key in obj) {
             if (obj[key]) {
               s += "      " + key + "\n";
-            }  
+            }
           }
         }
         if (needFix) {
@@ -193,14 +193,14 @@ qx.Class.define("qx.tool.cli.commands.package.Migrate", {
             }
           }
         }
-        // update dependencies
+        // check framework and compiler dependencies
+        // if none are given in the Manifest, use the present framework and compiler
         const compiler_version = qx.tool.compiler.Version.VERSION;
-        const compiler_range = manifestModel.getValue("requires.@qooxdoo/compiler");
+        const compiler_range = manifestModel.getValue("requires.@qooxdoo/compiler") || compiler_version;
         const framework_version = await this.getLibraryVersion(await this.getGlobalQxPath());
-        const framework_range = manifestModel.getValue("requires.@qooxdoo/framework");
+        const framework_range = manifestModel.getValue("requires.@qooxdoo/framework") || framework_version;
 
         if (
-          !(compiler_range && framework_range) ||
           !semver.satisfies(compiler_version, compiler_range) ||
           !semver.satisfies(framework_version, framework_range)) {
           needFix = true;


### PR DESCRIPTION
Otherwise trying to compile the framework will result in having to `qx package migrate`, which will add these ranges back into the framework, which is not what we want. 