### PR TITLE
Sort package cache data by release date

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5287,6 +5287,14 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -5321,6 +5329,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonlint": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "description": "node.js based replacement for the Qooxdoo python toolchain",
   "main": "index.js",
   "scripts": {
-    "devtools" : "node source/resource/qx/tool/bin/build-devtools",
-    "website" : "node source/resource/qx/tool/bin/build-website",
+    "devtools": "node source/resource/qx/tool/bin/build-devtools",
+    "website": "node source/resource/qx/tool/bin/build-website",
     "test": "cross-os test.os",
     "prepare": "npm update --no-save @qooxdoo/framework",
     "prepack": "npm update --save @qooxdoo/framework && npm shrinkwrap"
@@ -71,6 +71,7 @@
     "glob": "^7.1.6",
     "image-size": "^0.6.3",
     "inquirer": "^6.5.2",
+    "json-stable-stringify": "^1.0.1",
     "jsonlint": "^1.6.2",
     "jstransformer-dot": "^0.1.2",
     "metalsmith": "^2.3.0",

--- a/source/class/qx/tool/cli/commands/Package.js
+++ b/source/class/qx/tool/cli/commands/Package.js
@@ -23,7 +23,7 @@ const fs = qx.tool.utils.Promisify.fs;
 const path = require("upath");
 const process = require("process");
 const jsonlint = require("jsonlint");
-const stringify = require('json-stable-stringify');
+const stringify = require("json-stable-stringify");
 
 /**
  * Handles library packages

--- a/source/class/qx/tool/cli/commands/Package.js
+++ b/source/class/qx/tool/cli/commands/Package.js
@@ -23,6 +23,7 @@ const fs = qx.tool.utils.Promisify.fs;
 const path = require("upath");
 const process = require("process");
 const jsonlint = require("jsonlint");
+const stringify = require('json-stable-stringify');
 
 /**
  * Handles library packages
@@ -256,7 +257,9 @@ qx.Class.define("qx.tool.cli.commands.Package", {
      */
     exportCache : async function(path) {
       try {
-        await fs.writeFileAsync(path, JSON.stringify(this.__cache, null, 2), "UTF-8");
+        let cache = this.__cache || this.getCache(true);
+        let data = stringify(cache, {space: 2});
+        await fs.writeFileAsync(path, data, "UTF-8");
       } catch (e) {
         qx.tool.compiler.Console.error(`Error exporting cache to ${path}:` + e.message);
         process.exit(1);

--- a/source/class/qx/tool/cli/commands/package/Install.js
+++ b/source/class/qx/tool/cli/commands/package/Install.js
@@ -282,7 +282,7 @@ qx.Class.define("qx.tool.cli.commands.package.Install", {
       if (!release_data) {
         throw new qx.tool.utils.Utils.UserError(`'${repo_name}' has no release '${tag_name}'.`);
       }
-      // TODO: the path in the cache data should be the path to the library containing Manifest.json, not to the Manifest.json itself
+      // TO DO: the path in the cache data should be the path to the library containing Manifest.json, not to the Manifest.json itself
       for (let {path:manifest_path} of release_data.manifests) {
         if (package_path && (path.dirname(manifest_path) !== package_path)) {
           // if a path component exists, only install the library in this path

--- a/source/class/qx/tool/cli/commands/package/Update.js
+++ b/source/class/qx/tool/cli/commands/package/Update.js
@@ -60,6 +60,10 @@ qx.Class.define("qx.tool.cli.commands.package.Update", {
           "quiet": {
             alias: "q",
             describe: "No output"
+          },
+          "export-only": {
+            alias: "E",
+            describe: "Export the current cache without updating it first (requires --file)"
           }
         }
       };
@@ -76,7 +80,18 @@ qx.Class.define("qx.tool.cli.commands.package.Update", {
       let names = [];
       const argv = this.argv;
       const update_repo_only = argv.repository;
-      if (!update_repo_only) {
+
+      // export only
+      if (argv.exportOnly) {
+        if (!argv.file) {
+          qx.tool.compiler.Console.error("Path required via --file argument.");
+          process.exit(1);
+        }
+        return this.exportCache(argv.file);
+      }
+
+
+        if (!update_repo_only) {
         this.clearCache();
       }
 
@@ -117,11 +132,10 @@ qx.Class.define("qx.tool.cli.commands.package.Update", {
         qx.tool.compiler.Console.info(`Run 'qx package list' in the root dir of your project to see which versions of these libraries are compatible.`);
       }
 
-      // save cache
+      // save cache and export it if requested
+      await this.saveCache();
       if (argv.file) {
         await this.exportCache(argv.file);
-      } else {
-        await this.saveCache();
       }
 
       async function updateFromRepository() {

--- a/source/class/qx/tool/cli/commands/package/Update.js
+++ b/source/class/qx/tool/cli/commands/package/Update.js
@@ -87,11 +87,12 @@ qx.Class.define("qx.tool.cli.commands.package.Update", {
           qx.tool.compiler.Console.error("Path required via --file argument.");
           process.exit(1);
         }
-        return this.exportCache(argv.file);
+        this.exportCache(argv.file);
+        return;
       }
 
 
-        if (!update_repo_only) {
+      if (!update_repo_only) {
         this.clearCache();
       }
 
@@ -263,7 +264,7 @@ qx.Class.define("qx.tool.cli.commands.package.Update", {
                 }
               }
               // we have a list of Manifest.json paths!
-              manifests = data.libraries || data.contribs; // todo remove data.contribs. eventually, only there for BC
+              manifests = data.libraries || data.contribs; // to do remove data.contribs. eventually, only there for BC
             } catch (e) {
               // no qooxdoo.json
               if (e.message.match(/404/)) {

--- a/source/class/qx/tool/cli/commands/package/Update.js
+++ b/source/class/qx/tool/cli/commands/package/Update.js
@@ -357,6 +357,9 @@ qx.Class.define("qx.tool.cli.commands.package.Update", {
             let zip_url = `https://github.com/${name}/archive/${tag_name}.zip`;
             releases.list.push(tag_name);
             releases.data[tag_name] = {
+              id: release.id,
+              published_at: release.published_at,
+              comment: release.body,
               title: release.name,
               prerelease: release.prerelease,
               manifests,


### PR DESCRIPTION
 `published_at` will be used for sorting the cache so that the diffs become easier to read.