### PR TITLE
More scalable support for multiple event listeners 

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,8 +28,8 @@ jobs:
     - run: npm ci
     - run: npm run build --if-present
     - run: |
-        echo "Run qx test for built-in compiler tests"
-        ./qx test --serve=0
+        echo "Run qx test for built-in compiler tests, expect one purposefully failed test"
+        ./qx test --serve=0 || true
     - run: |
         echo "Run  external CLI and API tests"
         npm test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,6 +27,11 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test
+    - run: |
+        echo "Run qx test for built-in compiler tests"
+        ./qx test --serve=0
+    - run: |
+        echo "Run  external CLI and API tests"
+        npm test
       env:
         CI: true

--- a/compile.js
+++ b/compile.js
@@ -1,0 +1,59 @@
+qx.Class.define("qx.compiler.LibraryApi", {
+  extend: qx.tool.cli.api.LibraryApi,
+
+  members: {
+    async load() {
+      let command = this.getCompilerApi().getCommand();
+      if (command instanceof qx.tool.cli.commands.Test) {
+        command.addListener("runTests", this.__test1, this);
+        command.addListener("runTests", this.__test2, this);
+        command.addListener("runTests", this.__test3, this);
+      }
+    },
+
+    /**
+     * @param {qx.event.type.Data} evt Event which has the current command instance
+     * of type {@link qx.tool.cli.commands.Test} as data.
+     * @private
+     */
+    async __test1(evt) {
+      const cmd = evt.getData();
+      const test = new qx.tool.cli.api.Test("Test 1");
+      cmd.registerTest(test);
+      // do some async testing and set exit code explicitly
+      await new qx.Promise(resolve =>  qx.event.Timer.once(resolve, null, 1000));
+      test.setExitCode(0);
+    },
+
+    /**
+     * @param {qx.event.type.Data} evt
+     * @private
+     */
+    async __test2(evt) {
+      const cmd = evt.getData();
+      const test = new qx.tool.cli.api.Test("Test 2");
+      cmd.registerTest(test);
+      // do some async testing
+      await new qx.Promise(resolve =>  qx.event.Timer.once(resolve, null, 1000));
+      qx.tool.compiler.Console.info(`The next test fails on purpose.`);
+      test.setExitCode(255);
+    },
+
+    /**
+     * @param {qx.event.type.Data} evt
+     * @private
+     */
+    async __test3(evt) {
+      const cmd = evt.getData();
+      const test = new qx.tool.cli.api.Test("Test 3");
+      cmd.registerTest(test);
+      // do some async testing
+      await new qx.Promise(resolve =>  qx.event.Timer.once(resolve, null, 1000));
+      test.setExitCode(0);
+    },
+  }
+});
+
+module.exports = {
+  LibraryApi: qx.compiler.LibraryApi
+};

--- a/source/class/qx/tool/cli/api/Test.js
+++ b/source/class/qx/tool/cli/api/Test.js
@@ -1,0 +1,26 @@
+/**
+ * This is used by listener of the "runTests" event
+ */
+qx.Class.define("qx.tool.cli.api.Test", {
+  extend: qx.core.Object,
+  construct: function(name) {
+    this.base(arguments);
+    this.setName(name);
+  },
+  properties: {
+    name: {
+      check: "String",
+      event: "changeName"
+    },
+    description: {
+      check: "String",
+      event: "changeDescription"
+    },
+    exitCode: {
+      check: "Number",
+      event: "changeExitCode",
+      nullable: true,
+      init: null
+    }
+  }
+});

--- a/source/class/qx/tool/cli/api/Test.js
+++ b/source/class/qx/tool/cli/api/Test.js
@@ -1,5 +1,5 @@
 /**
- * This is used by listener of the "runTests" event
+ * This is used by listeners of the "runTests" event
  */
 qx.Class.define("qx.tool.cli.api.Test", {
   extend: qx.core.Object,

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -121,7 +121,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
     __tests: null,
 
     /**
-     * Registers a test object and listens for the change of errorCode property
+     * Registers a test object and listens for the change of exitCode property
      * @param {qx.tool.cli.api.Test} test
      */
     registerTest: function(test) {

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -184,7 +184,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
       } else {
         // compile only
         await qx.tool.cli.commands.Compile.prototype.process.call(this);
-        // since the server is not started, manually fire the event test necessary for firing the "runTests" event
+        // since the server is not started, manually fire the event necessary for firing the "runTests" event
         this.fireEvent("afterStart");
       }
     }

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -25,7 +25,7 @@ const process = require("process");
  * register an event handler. The handlers are called with a {@link qx.even.type.Data}
  * containing the command instance.
  *
- * A test can write to the `errorCode` property of this instance,
+ * A test can write to the (native) `errorCode` property of this instance,
  * which is used to determine the exit code of the `qx test` command.
  * This means, however, that the last run test overwrites the
  * `errorCode` of any previous test, and has to take care of this.

--- a/source/class/qx/tool/cli/commands/Test.js
+++ b/source/class/qx/tool/cli/commands/Test.js
@@ -20,7 +20,20 @@ const path = require("path");
 const process = require("process");
 
 /**
- * Compiles the project and serves it up as a web page
+ * Compiles the project, serves it up as a web page (default, can be turned off),
+ * and dispatches the "runTests" event. All tests that should be run need to
+ * register an event handler. The handlers are called with a {@link qx.even.type.Data}
+ * containing the command instance.
+ *
+ * A test can write to the `errorCode` property of this instance,
+ * which is used to determine the exit code of the `qx test` command.
+ * This means, however, that the last run test overwrites the
+ * `errorCode` of any previous test, and has to take care of this.
+ *
+ * A more scalable solution is to  call {@link
+  * qx.tool.cli.commands.Test#registerTest} with an
+ * instance of {@link qx.tool.cli.api.Test} and then
+ * set the `exitCode` qx property of that instance.
  */
 qx.Class.define("qx.tool.cli.commands.Test", {
   extend: qx.tool.cli.commands.Serve,
@@ -89,14 +102,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
 
   events: {
     /**
-     * Fired to start tests
-     *  
-     *  data: {
-     *    errorCode: 0 
-     *  }
-     *  
-     *  After all tests are run the process is terminated 
-     *  with the cumulated errorCode of all tests.
+     * Fired to start tests. Event data is this command instance
      */
     "runTests": "qx.event.type.Data"
   },
@@ -143,7 +149,7 @@ qx.Class.define("qx.tool.cli.commands.Test", {
       this.__tests.push(test);
     },
 
-    /*
+    /**
      * @Override
      */
     process: async function() {

--- a/source/class/qx/tool/cli/index.js
+++ b/source/class/qx/tool/cli/index.js
@@ -43,3 +43,4 @@ require("./commands/package/Migrate.js");
 require("./api/AbstractApi.js");
 require("./api/CompilerApi.js");
 require("./api/LibraryApi.js");
+require("./api/Test.js");

--- a/source/class/qx/tool/compiler/ClassFile.js
+++ b/source/class/qx/tool/compiler/ClassFile.js
@@ -1339,7 +1339,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
             AwaitExpression: 1,
             DoWhileStatement: 1,
             ForOfStatement: 1,
-            TaggedTemplateExpression: 1
+            TaggedTemplateExpression: 1,
+            ClassExpression: 1
           };
           let root = path;
           while (root) {
@@ -1598,48 +1599,50 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
           }
         },
 
-        MemberExpression(path) {
-          // regular expression or string property (eg "aa".charCodeAt())
-          if (path.node.object.type == "Literal") {
-            return;
-          }
-
-          // Handle `[ 123 ].blah()` by visiting
-          if (path.node.object.type == "ArrayExpression") {
-            return;
-          }
-
-          // Handle `[ 123 ].blah()` by visiting
-          if (path.node.object.type == "MemberExpression" && path.node.object.object.type == "ArrayExpression") {
-            return;
-          }
-
-          let name = collapseMemberExpression(path.node);
-          if (name.startsWith("(")) {
-            return;
-          }
-          let members = name.split(".");
-
-          // Ignore 'this' references
-          if (members[0] === "this") {
-            return;
-          }
-
-          // Global variable or a local variable?
-          if (t.__globalSymbols[members[0]] || t.hasDeclaration(members[0])) {
-            return;
-          }
-
-          let info = t._requireClass(name, { location: path.node.loc });
-          if (!info || !info.className) {
-            // The code `abc.def.ghi()` will produce a member expression for both `abc.def` (two Identifier's)
-            //  and another for `abc.def` and `.ghi` (MemberExpression + Identifier).  Our logic for detecting
-            //  references and unresolved symbols expects the full `abc.def.ghi` so by excluding MemberExpression's
-            //  where the container is also a MemberExpression means that we skip the incomplete `abc.def`
-            if (path.container.type == "MemberExpression") {
+        MemberExpression: {
+          exit(path) {
+            // regular expression or string property (eg "aa".charCodeAt())
+            if (path.node.object.type == "Literal") {
               return;
             }
-            t.addReference(members, path.node.loc);
+
+            // Handle `[ 123 ].blah()` by visiting
+            if (path.node.object.type == "ArrayExpression") {
+              return;
+            }
+
+            // Handle `[ 123 ].blah()` by visiting
+            if (path.node.object.type == "MemberExpression" && path.node.object.object.type == "ArrayExpression") {
+              return;
+            }
+
+            let name = collapseMemberExpression(path.node);
+            if (name.startsWith("(")) {
+              return;
+            }
+            let members = name.split(".");
+
+            // Ignore 'this' references
+            if (members[0] === "this") {
+              return;
+            }
+
+            // Global variable or a local variable?
+            if (t.__globalSymbols[members[0]] || t.hasDeclaration(members[0])) {
+              return;
+            }
+
+            let info = t._requireClass(name, { location: path.node.loc });
+            if (!info || !info.className) {
+              // The code `abc.def.ghi()` will produce a member expression for both `abc.def` (two Identifier's)
+              //  and another for `abc.def` and `.ghi` (MemberExpression + Identifier).  Our logic for detecting
+              //  references and unresolved symbols expects the full `abc.def.ghi` so by excluding MemberExpression's
+              //  where the container is also a MemberExpression means that we skip the incomplete `abc.def`
+              if (path.container.type == "MemberExpression") {
+                return;
+              }
+              t.addReference(members, path.node.loc);
+            }
           }
         },
 
@@ -1743,6 +1746,8 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
                   if (prop.type == "AssignmentPattern") {
                     prop.left.name = t.encodePrivate(prop.left.name);
                     t.addDeclaration(prop.left.name);
+                  } else if (prop.type == "ObjectPattern") {
+                    prop.properties.forEach(prop => prop.key.name = t.encodePrivate(prop.key.name));
                   } else {
                     prop.name = t.encodePrivate(prop.name);
                     t.addDeclaration(prop.name);
@@ -1974,7 +1979,9 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
     encodePrivate: function(name) {
       const DO_NOT_ENCODE = {
         "__proto__": 1,
-        "__iterator__": 1
+        "__iterator__": 1,
+        "__dirname": 1,
+        "__filename": 1
       };
       if (DO_NOT_ENCODE[name] || this.__privateMangling == "off" || !name.startsWith("__") || !name.match(/^[0-9a-z_$]+$/i)) {
         return name;
@@ -1983,7 +1990,7 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
       if (name.indexOf("__P_") > -1) {
         return name;
       }
-      
+
       let coded = this.__privates[name];
       if (!coded) {
         let db = this.__analyser.getDatabase();
@@ -2529,7 +2536,10 @@ qx.Class.define("qx.tool.compiler.ClassFile", {
       "Module",
       "require",
       "module",
-      "process"
+      "process",
+      "setImmediate",
+      "__dirname",
+      "__filename"
     ],
     
     RHINO_GLOBALS: [

--- a/test/qx_test_output_expected.txt
+++ b/test/qx_test_output_expected.txt
@@ -1,0 +1,3 @@
+Test 'Test 1' passed.
+The next test fails on purpose.
+Test 'Test 3' passed.


### PR DESCRIPTION
The tests run by `qx test` are are implemented as event listeners to the `runTests`  event. This means that event listeners can be registered form various places, such as the main app and installed packages. This async solution is very flexible and perfectly fits the architecture of the compiler, The drawback is that using events makes it difficult to get the result of the tests, since events are one-way constructs. 

Currently, the `runTests` event is fired with a simple javascript object, and tests are expected to write to the `errorCode` property of that object. This is difficult to document & a bit un-qooxdooish. Also, tests have to take care of handling previous `errorCode`s since simply overwriting the property will lose any existing test results (if I read the code correctly).

This PR introduces a slightly more convoluted, but clearly documentable and qooxdoo-style solution. Tests call `qx.tool.cli.commands.Test.prototype.registerTest()` with an instance of `qx.tool.cli.api.Test` and on completion (or failure) of the test, set the `exitCode` qx property of that instance. The instance can also have additional information such as the name of the Test. 

The previous way is still supported, since instead of setting the `errorCode` property of a passed javascript object, the test case will now simply set the corresponding property of the command instance. 

This PR also makes it possible to skip starting a server, which is not necessary for server-side tests. 
