### PR TITLE
Make requires.resource and requires.translation optional & remove type

### DIFF
--- a/source/resource/qx/tool/schema/Manifest-1-0-0.json
+++ b/source/resource/qx/tool/schema/Manifest-1-0-0.json
@@ -110,9 +110,7 @@
     "provides": {
       "required": [
         "namespace",
-        "class",
-        "resource",
-        "translation"
+        "class"
       ],
       "additionalProperties": false,
       "type": "object",
@@ -177,11 +175,6 @@
               }
             }
           }
-        },
-        "type": {
-          "type": "string",
-          "pattern": "^(library|application|add-in|contribution)$",
-          "description": "Type of the project"
         },
         "application": {
           "type":"object"


### PR DESCRIPTION
`requires.resource` and `requires.translation` are not needed for every library and the absence of the resource directory produce unneccessary warning messages. 

The `type` key is not used anywhere (AFAIK), introducing this constraint without a proper use case limits us to change it in the future. 