### PR TITLE
npm link overwrite framework with current  npm version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "cross-os": {
     "test.os": {
       "win32": "test\\test.win32.cmd",
-      "linux": "test/test.linux.sh",
-      "darwin": "test/test.linux.sh"
+      "linux": "npm link && test/test.linux.sh",
+      "darwin": "npm link && test/test.linux.sh"
     }
   },
   "author": "John Spackman (johnspackman), Christian Boulanger (cboulanger), Henner Kollmann (hkollmann), and others",

--- a/test/test.linux.sh
+++ b/test/test.linux.sh
@@ -3,14 +3,14 @@ set -x
 set -e
 NODE_OPTS="--no-warnings"
 
-npm link
+#npm link
 
 echo "Testing qooxdoo-compiler version $(./qx --version)"
 echo
 
-./qx package update
-./qx package install
-./qx lint
+npx qx package update
+npx qx package install
+npx qx lint
 
 # node API tests
 pushd test


### PR DESCRIPTION
- so test in framework will not use the just copied version