### PR TITLE
Change let to var in template to ensure backward compatibility

### DIFF
--- a/source/resource/qx/tool/cli/templates/loader/loader-browser.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/loader/loader-browser.tmpl.js
@@ -140,7 +140,7 @@ qx.$$loader = {
   on: function(eventType, handler) {
     if (qx.$$loader.applicationHandlerReady) {
       if (window.qx && qx.event && qx.event.handler && qx.event.handler.Application) {
-        let Application = qx.event.handler.Application.$$instance;
+        var Application = qx.event.handler.Application.$$instance;
         if (eventType == "ready" && Application.isApplicationReady()) {
           handler(null);
           return;


### PR DESCRIPTION
Hi,
As said on gitter, like this let is not impact by user babel setting it prevents users to do old browser compatibility (broswer without let support).