### PR TITLE
Fix interpretation of "\n" on translation when the message is on several lines

### DIFF
--- a/source/class/qx/tool/compiler/app/Translation.js
+++ b/source/class/qx/tool/compiler/app/Translation.js
@@ -269,6 +269,10 @@ qx.Class.define("qx.tool.compiler.app.Translation", {
                 }
               });
 
+              if(entry) {
+                saveEntry();
+              }
+
               resolve();
             });
         });

--- a/source/class/qx/tool/compiler/app/Translation.js
+++ b/source/class/qx/tool/compiler/app/Translation.js
@@ -148,6 +148,9 @@ qx.Class.define("qx.tool.compiler.app.Translation", {
               function set(key, value, append) {
                 var index = null;
                 var m = key.match(/^([^[]+)\[([0-9]+)\]$/);
+                value = value.replace(/\\t/g, "\t").replace(/\\r/g, "\r")
+                  .replace(/\\n/g, "\n")
+                  .replace(/\\"/g, "\"");
                 if (m) {
                   key = m[1];
                   index = parseInt(m[2]);
@@ -262,9 +265,6 @@ qx.Class.define("qx.tool.compiler.app.Translation", {
                 var value = m[2];
                 if (value.length >= 2 && value[0] == "\"" && value[value.length - 1] == "\"") {
                   value = value.substring(1, value.length - 1);
-                  value = value.replace(/\\t/g, "\t").replace(/\\r/g, "\r")
-                    .replace(/\\n/g, "\n")
-                    .replace(/\\"/g, "\"");
                   set(key, value);
                 }
               });


### PR DESCRIPTION
Currently when you use multiple line in po file, for example: 

    msgid "MY_MESSAGE_ID"
    msgstr " This is a \n message on several lines\n"
    "Because it's clearer \n"
    "---------------------------------------\n"
    "To write \n"
    "And read \n"
    "Like this \n"
    "---------------------------------------"

Only the "\n" on the first line (the one with msgstr) will be interpreted, the final string will be :

    "This is a 
    message on several lines
    Because it's clearer \n---------------------------------------\nTo write \nAnd read \nLike this \n---------------------------------------"

It was because the compiler use a regex to replace "\\n" (what you obtain with read function) with "\n" (real line separator) however the test was only made in the part of the code executed when we have msgstr key on the line, the other line of the message string were juste append to previous text without any replacement. I just move the part of code to allow all value to be treated.