### PR TITLE
Edit browser template to use new index.js instead of boot.js when loading scripts on IE11

### DIFF
--- a/source/resource/qx/tool/cli/templates/loader/loader-browser.tmpl.js
+++ b/source/resource/qx/tool/cli/templates/loader/loader-browser.tmpl.js
@@ -12,7 +12,7 @@ if (!qx.$$appRoot) {
   if (!bootScriptElement) {
     var scripts = document.getElementsByTagName('script');
     for (var i = 0; i < scripts.length; i++) {
-      if (scripts[i].src && scripts[i].src.match(/boot\.js/)) {
+      if (scripts[i].src && scripts[i].src.match(/index\.js/)) {
         bootScriptElement = scripts[i];
         break;
       }


### PR DESCRIPTION
Currently the apps using externalScripts can't be launched on IE11