### PR TITLE
fix for #773

### DIFF
--- a/source/class/qx/tool/cli/commands/package/Publish.js
+++ b/source/class/qx/tool/cli/commands/package/Publish.js
@@ -343,7 +343,7 @@ qx.Class.define("qx.tool.cli.commands.package.Publish", {
       const topic = "qooxdoo-package";
       if (!topics.includes(topic)) {
         topics.push(topic);
-        await octokit.repos.replaceTopics({owner,
+        await octokit.repos.replaceAllTopics({owner,
           repo,
           names:topics});
         if (!argv.quiet) {


### PR DESCRIPTION
See release notes: 

https://openbase.io/js/@octokit/rest/versions:
octokit.repos.replaceTopics() has been renamed to  octokit.repos.replaceAllTopics()