### PR TITLE
cache and use-eslintrc are booleans

### DIFF
--- a/source/class/qx/tool/cli/commands/Lint.js
+++ b/source/class/qx/tool/cli/commands/Lint.js
@@ -40,11 +40,13 @@ qx.Class.define("qx.tool.cli.commands.Lint", {
           },
           "use-eslintrc": {
             describe: "Use the .eslintrc file for configuration, if it exists",
-            default: true
+            default: true,
+            type: "boolean"
           },
           "cache": {
             describe: "operate only on changed files",
-            default: false
+            default: false,
+            type: "boolean"
           },
           "warnAsError": {
             alias: "w",


### PR DESCRIPTION
The options `--cache` and `--use-eslintrc` are recognized as `string` and they remain always true. This PR sets them as `boolean` so the yargs translates them properly.. 